### PR TITLE
Quick fix for TypeError caused by httplib2/Python3 returning a bytes object instead of a string.

### DIFF
--- a/hp3parclient/http.py
+++ b/hp3parclient/http.py
@@ -186,6 +186,8 @@ class HTTPJSONRESTClient(httplib2.Http):
 
         self._http_log_req(args, kwargs)
         resp, body = super(HTTPJSONRESTClient, self).request(*args, **kwargs)
+        if isinstance(body, bytes):
+            body = body.decode('utf-8')
         self._http_log_resp(resp, body)
 
         # Try and conver the body response to an object


### PR DESCRIPTION
With Python3, all JSON parsing in hp3parclient API fails as httplib2.Http.request() now returns a bytes object instead of a string.

Quick fix is to convert it back to good old string object. I believe it is safe to hardcode it as UTF-8...

See also: https://code.google.com/p/httplib2/wiki/ExamplesPython3