### PR TITLE
Add support for iscsi vlan tagging

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Changes in Version 4.2.9
+------------------------
+* Added support for querying iscsi vlan tagged ports in getPorts call
+
 Changes in Version 4.2.8
 ------------------------
 * Added further support for Remote Copy Operations:

--- a/hpe3parclient/__init__.py
+++ b/hpe3parclient/__init__.py
@@ -22,7 +22,7 @@ HPE 3PAR Client.
 
 """
 
-version_tuple = (4, 2, 8)
+version_tuple = (4, 2, 9)
 
 
 def get_version_string():

--- a/hpe3parclient/client.py
+++ b/hpe3parclient/client.py
@@ -1893,11 +1893,7 @@ class HPE3ParClient(object):
                 iscsi_vlan_data = self._run(['showport', '-iscsivlans'])
                 port_parser = showport_parser.ShowportParser()
                 iscsi_ports = port_parser.parseShowport(iscsi_vlan_data)
-                print('body')
-                print(body)
                 expanded_ports = self._cloneISCSIPorts(body, iscsi_ports)
-                print("asif")
-                print(expanded_ports)
                 for cli_port in expanded_ports:
                     for wsapi_port in body[u'members']:
                         if wsapi_port['portPos']['node'] == \

--- a/hpe3parclient/client.py
+++ b/hpe3parclient/client.py
@@ -41,8 +41,8 @@ except ImportError:
 from hpe3parclient import exceptions, http, ssh
 from hpe3parclient import showport_parser
 
-class HPE3ParClient(object):
 
+class HPE3ParClient(object):
     """ The 3PAR REST API Client.
 
     :param api_url: The url to the WSAPI service on 3PAR
@@ -141,23 +141,23 @@ class HPE3ParClient(object):
     VLUN_MULTIPATH_ROUND_ROBIN = 2
     VLUN_MULTIPATH_FAILOVER = 3
 
-    CPG_RAID_R0 = 1     # RAID 0
-    CPG_RAID_R1 = 2     # RAID 1
-    CPG_RAID_R5 = 3     # RAID 5
-    CPG_RAID_R6 = 4     # RAID 6
+    CPG_RAID_R0 = 1  # RAID 0
+    CPG_RAID_R1 = 2  # RAID 1
+    CPG_RAID_R5 = 3  # RAID 5
+    CPG_RAID_R6 = 4  # RAID 6
 
-    CPG_HA_PORT = 1     # Support failure of a port.
-    CPG_HA_CAGE = 2     # Support failure of a drive cage.
-    CPG_HA_MAG = 3      # Support failure of a drive magazine.
+    CPG_HA_PORT = 1  # Support failure of a port.
+    CPG_HA_CAGE = 2  # Support failure of a drive cage.
+    CPG_HA_MAG = 3  # Support failure of a drive magazine.
 
     # Lowest numbered available chunklets, where transfer rate is the fastest.
     CPG_CHUNKLET_POS_PREF_FIRST = 1
     # Highest numbered available chunklets, where transfer rate is the slowest.
     CPG_CHUNKLET_POS_PREF_LAST = 2
 
-    CPG_DISK_TYPE_FC = 1        # Fibre Channel
-    CPG_DISK_TYPE_NL = 2        # Near Line
-    CPG_DISK_TYPE_SSD = 3       # SSD
+    CPG_DISK_TYPE_FC = 1  # Fibre Channel
+    CPG_DISK_TYPE_NL = 2  # Near Line
+    CPG_DISK_TYPE_SSD = 3  # SSD
 
     HOST_EDIT_ADD = 1
     HOST_EDIT_REMOVE = 2
@@ -220,14 +220,14 @@ class HPE3ParClient(object):
         # e.g. 30102422 is 3 01 02 422
         # therefore all we need to compare is the build
         if (api_version is None or
-           api_version['build'] < self.HPE3PAR_WS_MIN_BUILD_VERSION):
+                api_version['build'] < self.HPE3PAR_WS_MIN_BUILD_VERSION):
             raise exceptions.UnsupportedVersion(
                 'Invalid 3PAR WS API, requires version, %s' %
                 self.HPE3PAR_WS_MIN_BUILD_VERSION_DESC)
 
         # Check for VLUN query support.
         if (api_version['build'] >=
-           self.HPE3PAR_WS_MIN_BUILD_VERSION_VLUN_QUERY):
+                self.HPE3PAR_WS_MIN_BUILD_VERSION_VLUN_QUERY):
             self.vlun_query_supported = True
 
     def setSSHOptions(self, ip, login, password, port=22,
@@ -1749,6 +1749,7 @@ class HPE3ParClient(object):
         :type wwn: str
 
         """
+
         # for now there is no search in the REST API
         # so we can do a create looking for a specific
         # error.  If we don't get that error, we nuke the
@@ -1881,19 +1882,18 @@ class HPE3ParClient(object):
 
         """
         response, body = self.http.get('/ports')
-        #if any of the ports are iSCSI ports and are vlan tagged
-        #then we need to get the iscsi ports and append them to
-        #the list of
+        # if any of the ports are iSCSI ports and are vlan tagged
+        # then we need to get the iscsi ports and append them to
+        # the list of
         if self.ssh is not None:
             if any([port['protocol'] == self.PORT_PROTO_ISCSI and
                     'iSCSIPortInfo' in port and
                     port['iSCSIPortInfo']['vlan'] == 1
                     for port in body['members']]):
-
                 iscsi_vlan_data = self._getISCSIVlans()
-                port_parser     = showport_parser.ShowportParser()
-                iscsi_ports     = port_parser.parseShowport(iscsi_vlan_data)
-                expanded_ports  = self._cloneISCSIPorts(body, iscsi_ports)
+                port_parser = showport_parser.ShowportParser()
+                iscsi_ports = port_parser.parseShowport(iscsi_vlan_data)
+                expanded_ports = self._cloneISCSIPorts(body, iscsi_ports)
                 body['members'].extend(expanded_ports)
                 body['total'] = len(body['members'])
 
@@ -1917,17 +1917,17 @@ class HPE3ParClient(object):
         for port in vlan_ports:
             matching_ports = [
                 x for x in real_ports['members']
-                if  (x['protocol'] == self.PORT_PROTO_ISCSI and
-                     x['iSCSIPortInfo']['vlan'] == 1 and
-                     x['portPos'] == port['portPos'])
+                if (x['protocol'] == self.PORT_PROTO_ISCSI and
+                    x['iSCSIPortInfo']['vlan'] == 1 and
+                    x['portPos'] == port['portPos'])
             ]
 
-             #should only be one
+            # should only be one
             if len(matching_ports) > 1:
                 err = ("Found {} matching ports for vlan tagged iSCSI port "
                        "{}.  There should only be one.")
-                raise exceptions.NoUniqueMatch(err.format(len(matching_ports)
-                                                          , port))
+                raise exceptions.\
+                    NoUniqueMatch(err.format(len(matching_ports), port))
 
             if len(matching_ports) == 1:
                 new_port = copy.deepcopy(matching_ports[0])
@@ -2134,7 +2134,7 @@ class HPE3ParClient(object):
 
         raise exceptions.HTTPNotFound({'code': 'NON_EXISTENT_VLUN',
                                        'desc': "VLUN '%s' was not found" %
-                                       volumeName})
+                                               volumeName})
 
     def createVLUN(self, volumeName, lun=None, hostname=None, portPos=None,
                    noVcn=None, overrideLowerPriority=None, auto=False):
@@ -4244,8 +4244,8 @@ class HPE3ParClient(object):
         snapshots = []
         for volume in body['members']:
             if 'copyOf' in volume:
-                if(volume['copyOf'] == volName and
-                   volume['copyType'] == self.VIRTUAL_COPY):
+                if (volume['copyOf'] == volName and
+                        volume['copyType'] == self.VIRTUAL_COPY):
                     snapshots.append(volume['name'])
         return snapshots
 
@@ -4395,8 +4395,8 @@ class HPE3ParClient(object):
             if item.startswith(targetName):
                 link_info = item.split(',')
                 if link_info[0] == targetName and \
-                   link_info[1] == local_port and \
-                   link_info[2] == target_system_peer_port:
+                        link_info[1] == local_port and \
+                        link_info[2] == target_system_peer_port:
                     return True
         return False
 
@@ -4432,8 +4432,9 @@ class HPE3ParClient(object):
             volumePairs = optional.get('volumePairs')
             if volumePairs is not None:
                 for volumePair in volumePairs:
-                    source_target_pair = volumePair['sourceVolumeName'] + \
-                        ':' + volumePair['targetVolumeName']
+                    source_target_pair = \
+                        volumePair['sourceVolumeName'] + ':' + \
+                        volumePair['targetVolumeName']
                     cmd.append(source_target_pair)
         response = self._run(cmd)
         err_resp = self.check_response_for_admittarget(response, targetName)
@@ -4508,20 +4509,22 @@ class HPE3ParClient(object):
         """
         for r in resp:
             if 'error' in str.lower(r) or 'invalid' in str.lower(r) \
-               or 'must specify a mapping' in str.lower(r) \
-               or 'not exist' in str.lower(r) or 'no target' in str.lower(r) \
-               or 'group contains' in str.lower(r) \
-               or 'Target is already in this group.' in str(r) \
-               or 'could not locate an indicated volume.' in str(r) \
-               or 'Target system %s could not be contacted' % targetName \
-               in str(r) \
-               or 'Target %s could not get info on secondary target' \
-               % targetName in str(r) \
-               or 'Target %s is not up and ready' % targetName in str(r) \
-               or 'A group may have only a single synchronous target.' \
-               in str(r) or \
-               'cannot have groups with more than one synchronization mode' \
-               in str.lower(r):
+                    or 'must specify a mapping' in str.lower(r) \
+                    or 'not exist' in str.lower(r) \
+                    or 'no target' in str.lower(r) \
+                    or 'group contains' in str.lower(r) \
+                    or 'Target is already in this group.' in str(r) \
+                    or 'could not locate an indicated volume.' in str(r) \
+                    or 'Target system %s could not be contacted' % targetName \
+                    in str(r) \
+                    or 'Target %s could not get info on secondary target' \
+                    % targetName in str(r) \
+                    or 'Target %s is not up and ready' % targetName in str(r) \
+                    or 'A group may have only a single synchronous target.' \
+                    in str(r) or \
+                    'cannot have groups with more than one ' \
+                    'synchronization mode' \
+                    in str.lower(r):
                 return r
 
     def check_response(self, resp):

--- a/hpe3parclient/client.py
+++ b/hpe3parclient/client.py
@@ -29,6 +29,7 @@ This client requires and works with 3PAR InForm 3.1.3 MU1 firmware
 import re
 import time
 import uuid
+import copy
 
 try:
     # For Python 3.0 and later
@@ -38,7 +39,7 @@ except ImportError:
     from urllib2 import quote
 
 from hpe3parclient import exceptions, http, ssh
-
+from hpe3parclient import showport_parser
 
 class HPE3ParClient(object):
 
@@ -1880,6 +1881,21 @@ class HPE3ParClient(object):
 
         """
         response, body = self.http.get('/ports')
+        #if any of the ports are iSCSI ports and are vlan tagged
+        #then we need to get the iscsi ports and append them to
+        #the list of
+        if self.ssh is not None:
+            if any([port['protocol'] == self.PORT_PROTO_ISCSI and
+                    port['iSCSIPortInfo']['vlan'] == 1
+                    for port in body['members']]):
+
+                iscsi_vlan_data = self._getISCSIVlans()
+                port_parser     = showport_parser.ShowportParser()
+                iscsi_ports     = port_parser.parseShowport(iscsi_vlan_data)
+                expanded_ports  = self._cloneISCSIPorts(body, iscsi_ports)
+                body['members'].extend(expanded_ports)
+                body['total'] = len(body['members'])
+
         return body
 
     def _getProtocolPorts(self, protocol, state=None):
@@ -1894,6 +1910,36 @@ class HPE3ParClient(object):
                         return_ports.append(port)
 
         return return_ports
+
+    def _cloneISCSIPorts(self, real_ports, vlan_ports):
+        cloned_ports = []
+        for port in vlan_ports:
+            matching_ports = [
+                x for x in real_ports['members']
+                if  (x['protocol'] == self.PORT_PROTO_ISCSI and
+                     x['iSCSIPortInfo']['vlan'] == 1 and
+                     x['portPos'] == port['portPos'])
+            ]
+
+             #should only be one
+            if len(matching_ports) > 1:
+                err = ("Found {} matching ports for vlan tagged iSCSI port "
+                       "{}.  There should only be one.")
+                raise exceptions.NoUniqueMatch(err.format(len(matching_ports)
+                                                          , port))
+
+            if len(matching_ports) == 1:
+                new_port = copy.deepcopy(matching_ports[0])
+                new_port.update(port)
+                cloned_ports.append(new_port)
+
+        return cloned_ports
+
+    def _getISCSIVlans(self):
+        self.ssh.open()
+        iscsi_vlan_data = self.ssh.run(['showport', '-iscsivlans'])
+        self.ssh.close()
+        return iscsi_vlan_data
 
     def getFCPorts(self, state=None):
         """Get a list of Fibre Channel Ports.

--- a/hpe3parclient/client.py
+++ b/hpe3parclient/client.py
@@ -1894,7 +1894,15 @@ class HPE3ParClient(object):
                 port_parser = showport_parser.ShowportParser()
                 iscsi_ports = port_parser.parseShowport(iscsi_vlan_data)
                 expanded_ports = self._cloneISCSIPorts(body, iscsi_ports)
-                body['members'].extend(expanded_ports)
+                for cli_port in expanded_ports:
+                    for wsapi_port in body[u'members']:
+                        if wsapi_port['portPos']['node'] == \
+                                cli_port['portPos']['node']  \
+                           and wsapi_port['portPos']['slot'] == \
+                                cli_port['portPos']['slot'] \
+                           and wsapi_port['portPos']['cardPort'] == \
+                                cli_port['portPos']['cardPort']:
+                            port_parser._merge_dict(wsapi_port, cli_port)
                 body['total'] = len(body['members'])
 
         return body

--- a/hpe3parclient/client.py
+++ b/hpe3parclient/client.py
@@ -1893,7 +1893,11 @@ class HPE3ParClient(object):
                 iscsi_vlan_data = self._run(['showport', '-iscsivlans'])
                 port_parser = showport_parser.ShowportParser()
                 iscsi_ports = port_parser.parseShowport(iscsi_vlan_data)
+                print('body')
+                print(body)
                 expanded_ports = self._cloneISCSIPorts(body, iscsi_ports)
+                print("asif")
+                print(expanded_ports)
                 for cli_port in expanded_ports:
                     for wsapi_port in body[u'members']:
                         if wsapi_port['portPos']['node'] == \

--- a/hpe3parclient/client.py
+++ b/hpe3parclient/client.py
@@ -1936,7 +1936,7 @@ class HPE3ParClient(object):
 
         return cloned_ports
 
-    #def _getISCSIVlans(self):
+    # def _getISCSIVlans(self):
     #    self.ssh.open()
     #    iscsi_vlan_data = self.ssh.run(['showport', '-iscsivlans'])
     #    self.ssh.close()

--- a/hpe3parclient/client.py
+++ b/hpe3parclient/client.py
@@ -1886,6 +1886,7 @@ class HPE3ParClient(object):
         #the list of
         if self.ssh is not None:
             if any([port['protocol'] == self.PORT_PROTO_ISCSI and
+                    'iSCSIPortInfo' in port and
                     port['iSCSIPortInfo']['vlan'] == 1
                     for port in body['members']]):
 

--- a/hpe3parclient/client.py
+++ b/hpe3parclient/client.py
@@ -1883,8 +1883,8 @@ class HPE3ParClient(object):
         """
         response, body = self.http.get('/ports')
         # if any of the ports are iSCSI ports and are vlan tagged
-        # then we need to get the iscsi ports and append them to
-        # the list of
+        # then we need to get the iscsi ports and merge them to
+        # the list of cli output
         if self.ssh is not None:
             if any([port['protocol'] == self.PORT_PROTO_ISCSI and
                     'iSCSIPortInfo' in port and
@@ -1943,12 +1943,6 @@ class HPE3ParClient(object):
                 cloned_ports.append(new_port)
 
         return cloned_ports
-
-    # def _getISCSIVlans(self):
-    #    self.ssh.open()
-    #    iscsi_vlan_data = self.ssh.run(['showport', '-iscsivlans'])
-    #    self.ssh.close()
-    #    return iscsi_vlan_data
 
     def getFCPorts(self, state=None):
         """Get a list of Fibre Channel Ports.

--- a/hpe3parclient/client.py
+++ b/hpe3parclient/client.py
@@ -26,10 +26,10 @@ also supports running actions on the 3PAR that use SSH.
 This client requires and works with 3PAR InForm 3.1.3 MU1 firmware
 
 """
+import copy
 import re
 import time
 import uuid
-import copy
 
 try:
     # For Python 3.0 and later
@@ -1890,7 +1890,7 @@ class HPE3ParClient(object):
                     'iSCSIPortInfo' in port and
                     port['iSCSIPortInfo']['vlan'] == 1
                     for port in body['members']]):
-                iscsi_vlan_data = self._getISCSIVlans()
+                iscsi_vlan_data = self._run(['showport', '-iscsivlans'])
                 port_parser = showport_parser.ShowportParser()
                 iscsi_ports = port_parser.parseShowport(iscsi_vlan_data)
                 expanded_ports = self._cloneISCSIPorts(body, iscsi_ports)
@@ -1936,11 +1936,11 @@ class HPE3ParClient(object):
 
         return cloned_ports
 
-    def _getISCSIVlans(self):
-        self.ssh.open()
-        iscsi_vlan_data = self.ssh.run(['showport', '-iscsivlans'])
-        self.ssh.close()
-        return iscsi_vlan_data
+    #def _getISCSIVlans(self):
+    #    self.ssh.open()
+    #    iscsi_vlan_data = self.ssh.run(['showport', '-iscsivlans'])
+    #    self.ssh.close()
+    #    return iscsi_vlan_data
 
     def getFCPorts(self, state=None):
         """Get a list of Fibre Channel Ports.

--- a/hpe3parclient/client.py
+++ b/hpe3parclient/client.py
@@ -1882,9 +1882,10 @@ class HPE3ParClient(object):
 
         """
         response, body = self.http.get('/ports')
-        # if any of the ports are iSCSI ports and are vlan tagged
-        # then we need to get the iscsi ports and merge them to
-        # the list of cli output
+        # if any of the ports are iSCSI ports and
+        # are vlan tagged (as shown by showport -iscsivlans), then
+        # the port information is merged with the WSAPI
+        # returned port information.
         if self.ssh is not None:
             if any([port['protocol'] == self.PORT_PROTO_ISCSI and
                     'iSCSIPortInfo' in port and

--- a/hpe3parclient/showport_parser.py
+++ b/hpe3parclient/showport_parser.py
@@ -1,0 +1,152 @@
+# (c) Copyright 2015 Hewlett Packard Development Company, L.P.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import collections 
+""" Parser for 3PAR showport commands.
+
+:Author: Derek Chadwell
+
+:Description: Parser to create port objects similar to the json
+objects return by WSAPI commands. This functionality fills gaps
+in iscsi port data reported by WSAPI commands, namely iSCSI 
+ports with vlan tags.
+
+"""
+
+
+
+class ShowportParser:
+    """ Parses the following showport commands on an HP 3par array
+        showport
+        showport -iscsi
+        showpoer -iscsivlan
+    """
+
+    def __init__(self):
+        self.parser_methods_by_header = {
+                                       'N:S:P'     : self._parsePortLocation,
+                                       'VLAN'      : self._parseVlan,
+                                       'IPAddr'    : self._parseIPAddr,
+                                       'Gateway'   : self._parseGateway,
+                                       'MTU'       : self._parseMtu,
+                                       'TPGT'      : self._parseTpgt,
+                                       'STGT'      : self._parseSTGT,
+                                       'iSNS_Addr' : self._parseIsnsAddr,
+                                       'iSNS_Port' : self._parseIsnsPort,
+                                       'Netmask/PrefixLen' : self._parseNetmask,
+                                        }
+
+    def parseShowport(self, port_show_output):
+        """Parses the showports output from HP3Parclient.ssh.run([cmd])
+            Returns: an array of port-like dictionaries similar to what you
+                     get from the wsapi GET /ports endpoint.
+
+                NOTE: There are several pieces that showports doesn't 
+                      give you that don't exist in this output.
+        """
+        new_ports = []
+
+        #the last two lines are just a dashed line
+        #and the number of entries returned.  We don't want those
+        port_show_output = port_show_output[0:-2]
+
+        #The first array in the 
+        #ports output list is the headers
+        headers = port_show_output.pop(0).split(',')
+
+        #then parse each line and create a port-like 
+        #dictionary from it
+        for line in port_show_output:
+            new_port = {}
+            entries = line.split(',')
+            for i,entry in enumerate(entries):
+                parser = self.parser_methods_by_header[headers[i]]
+                self._merge_dict(new_port, parser(entry))
+
+            new_ports.append(new_port)
+
+        return new_ports
+
+
+    def _parsePortLocation(self, nps):
+        """Parse N:S:P data into a dictionary with key "portPost"
+            "portPos":{
+                "node":0,
+                "slot":0,
+                "cardPort":1
+            },
+        """ 
+
+        nps_array = nps.split(':')
+
+        port_pos = { 'portPos' : {
+                                'node'     : int(nps_array[0]),
+                                'slot'     : int(nps_array[1]),
+                                'cardPort' : int(nps_array[2])
+                                 }
+                   }
+        
+        return port_pos 
+
+
+    def _parseVlan(self, vlan):
+        """the vlan key/value pair as part of the iSCSIPortInfo dict"""
+        return {'iSCSIPortInfo' : {'vlan' : vlan}}
+
+    def _parseIPAddr(self,address):
+        """the IP key/value pair as part of the iSCSIPortInfo dict"""
+        return {'IPAddr'        : address,
+		'iSCSIPortInfo' : {'IPAddr' : address}}
+
+    def _parseGateway(self, gw):
+        """the gw key/value pair as part of the iSCSIPortInfo dict"""
+        return {'iSCSIPortInfo' : {'gateway' : gw}}
+        
+    def _parseMtu(self, mtu):
+        """the mtu key/value pair as part of the iSCSIPortInfo dict"""
+        return {'iSCSIPortInfo' : {'mtu' : int(mtu)}}
+
+    def _parseTpgt(self, tpgt):
+        """the tpgt key/value pair as part of the iSCSIPortInfo dict"""
+        return {'iSCSIPortInfo' : {'tpgt' : int(tpgt)}}
+
+    def _parseSTGT(self, stgt):
+        """the stgt key/value pair as part of the iSCSIPortInfo dict"""
+        return {'iSCSIPortInfo' : {'stgt' : int(stgt)}}
+
+    def _parseIsnsAddr(self, addr):
+        """the isns key/value pair as part of the iSCSIPortInfo dict"""
+        return {'iSCSIPortInfo' : {'iSNSAddr' : addr}}
+
+    def _parseIsnsPort(self, port):
+        """the isns key/value pair as part of the iSCSIPortInfo dict"""
+        return {'iSCSIPortInfo' : {'iSNSPort' : int(port)}}
+
+    def _parseNetmask(self, mask):
+        """the network key/value pair as part of the iSCSIPortInfo dict"""
+        return {'iSCSIPortInfo' : {'netmask' : mask}}
+
+    def _merge_dict(self, d1, d2):
+        """
+        Modifies d1 in-place to contain values from d2.  If any value
+        in d1 is a dictionary (or dict-like), *and* the corresponding
+        value in d2 is also a dictionary, then merge them in-place.
+        """
+        for k,v2 in d2.items():
+            v1 = d1.get(k) # returns None if v1 has no value for this key
+            if ( isinstance(v1, collections.Mapping) and 
+                 isinstance(v2, collections.Mapping) ):
+                self._merge_dict(v1, v2)
+            else:
+                d1[k] = v2
+

--- a/hpe3parclient/showport_parser.py
+++ b/hpe3parclient/showport_parser.py
@@ -11,18 +11,18 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-import collections 
+import collections
+
 """ Parser for 3PAR showport commands.
 
 :Author: Derek Chadwell
 
 :Description: Parser to create port objects similar to the json
 objects return by WSAPI commands. This functionality fills gaps
-in iscsi port data reported by WSAPI commands, namely iSCSI 
+in iscsi port data reported by WSAPI commands, namely iSCSI
 ports with vlan tags.
 
 """
-
 
 
 class ShowportParser:
@@ -34,49 +34,48 @@ class ShowportParser:
 
     def __init__(self):
         self.parser_methods_by_header = {
-                                       'N:S:P'     : self._parsePortLocation,
-                                       'VLAN'      : self._parseVlan,
-                                       'IPAddr'    : self._parseIPAddr,
-                                       'Gateway'   : self._parseGateway,
-                                       'MTU'       : self._parseMtu,
-                                       'TPGT'      : self._parseTpgt,
-                                       'STGT'      : self._parseSTGT,
-                                       'iSNS_Addr' : self._parseIsnsAddr,
-                                       'iSNS_Port' : self._parseIsnsPort,
-                                       'Netmask/PrefixLen' : self._parseNetmask,
-                                        }
+            'N:S:P': self._parsePortLocation,
+            'VLAN': self._parseVlan,
+            'IPAddr': self._parseIPAddr,
+            'Gateway': self._parseGateway,
+            'MTU': self._parseMtu,
+            'TPGT': self._parseTpgt,
+            'STGT': self._parseSTGT,
+            'iSNS_Addr': self._parseIsnsAddr,
+            'iSNS_Port': self._parseIsnsPort,
+            'Netmask/PrefixLen': self._parseNetmask,
+        }
 
     def parseShowport(self, port_show_output):
         """Parses the showports output from HP3Parclient.ssh.run([cmd])
             Returns: an array of port-like dictionaries similar to what you
                      get from the wsapi GET /ports endpoint.
 
-                NOTE: There are several pieces that showports doesn't 
+                NOTE: There are several pieces that showports doesn't
                       give you that don't exist in this output.
         """
         new_ports = []
 
-        #the last two lines are just a dashed line
-        #and the number of entries returned.  We don't want those
+        # the last two lines are just a dashed line
+        # and the number of entries returned.  We don't want those
         port_show_output = port_show_output[0:-2]
 
-        #The first array in the 
-        #ports output list is the headers
+        # The first array in the
+        # ports output list is the headers
         headers = port_show_output.pop(0).split(',')
 
-        #then parse each line and create a port-like 
-        #dictionary from it
+        # then parse each line and create a port-like
+        # dictionary from it
         for line in port_show_output:
             new_port = {}
             entries = line.split(',')
-            for i,entry in enumerate(entries):
+            for i, entry in enumerate(entries):
                 parser = self.parser_methods_by_header[headers[i]]
                 self._merge_dict(new_port, parser(entry))
 
             new_ports.append(new_port)
 
         return new_ports
-
 
     def _parsePortLocation(self, nps):
         """Parse N:S:P data into a dictionary with key "portPost"
@@ -85,56 +84,55 @@ class ShowportParser:
                 "slot":0,
                 "cardPort":1
             },
-        """ 
+        """
 
         nps_array = nps.split(':')
 
-        port_pos = { 'portPos' : {
-                                'node'     : int(nps_array[0]),
-                                'slot'     : int(nps_array[1]),
-                                'cardPort' : int(nps_array[2])
-                                 }
-                   }
-        
-        return port_pos 
+        port_pos = {'portPos': {
+            'node': int(nps_array[0]),
+            'slot': int(nps_array[1]),
+            'cardPort': int(nps_array[2])
+        }
+        }
 
+        return port_pos
 
     def _parseVlan(self, vlan):
         """the vlan key/value pair as part of the iSCSIPortInfo dict"""
-        return {'iSCSIPortInfo' : {'vlan' : vlan}}
+        return {'iSCSIPortInfo': {'vlan': vlan}}
 
-    def _parseIPAddr(self,address):
+    def _parseIPAddr(self, address):
         """the IP key/value pair as part of the iSCSIPortInfo dict"""
-        return {'IPAddr'        : address,
-		'iSCSIPortInfo' : {'IPAddr' : address}}
+        return {'IPAddr': address,
+                'iSCSIPortInfo': {'IPAddr': address}}
 
     def _parseGateway(self, gw):
         """the gw key/value pair as part of the iSCSIPortInfo dict"""
-        return {'iSCSIPortInfo' : {'gateway' : gw}}
-        
+        return {'iSCSIPortInfo': {'gateway': gw}}
+
     def _parseMtu(self, mtu):
         """the mtu key/value pair as part of the iSCSIPortInfo dict"""
-        return {'iSCSIPortInfo' : {'mtu' : int(mtu)}}
+        return {'iSCSIPortInfo': {'mtu': int(mtu)}}
 
     def _parseTpgt(self, tpgt):
         """the tpgt key/value pair as part of the iSCSIPortInfo dict"""
-        return {'iSCSIPortInfo' : {'tpgt' : int(tpgt)}}
+        return {'iSCSIPortInfo': {'tpgt': int(tpgt)}}
 
     def _parseSTGT(self, stgt):
         """the stgt key/value pair as part of the iSCSIPortInfo dict"""
-        return {'iSCSIPortInfo' : {'stgt' : int(stgt)}}
+        return {'iSCSIPortInfo': {'stgt': int(stgt)}}
 
     def _parseIsnsAddr(self, addr):
         """the isns key/value pair as part of the iSCSIPortInfo dict"""
-        return {'iSCSIPortInfo' : {'iSNSAddr' : addr}}
+        return {'iSCSIPortInfo': {'iSNSAddr': addr}}
 
     def _parseIsnsPort(self, port):
         """the isns key/value pair as part of the iSCSIPortInfo dict"""
-        return {'iSCSIPortInfo' : {'iSNSPort' : int(port)}}
+        return {'iSCSIPortInfo': {'iSNSPort': int(port)}}
 
     def _parseNetmask(self, mask):
         """the network key/value pair as part of the iSCSIPortInfo dict"""
-        return {'iSCSIPortInfo' : {'netmask' : mask}}
+        return {'iSCSIPortInfo': {'netmask': mask}}
 
     def _merge_dict(self, d1, d2):
         """
@@ -142,11 +140,10 @@ class ShowportParser:
         in d1 is a dictionary (or dict-like), *and* the corresponding
         value in d2 is also a dictionary, then merge them in-place.
         """
-        for k,v2 in d2.items():
-            v1 = d1.get(k) # returns None if v1 has no value for this key
-            if ( isinstance(v1, collections.Mapping) and 
-                 isinstance(v2, collections.Mapping) ):
+        for k, v2 in d2.items():
+            v1 = d1.get(k)  # returns None if v1 has no value for this key
+            if (isinstance(v1, collections.Mapping) and
+                    isinstance(v2, collections.Mapping)):
                 self._merge_dict(v1, v2)
             else:
                 d1[k] = v2
-

--- a/hpe3parclient/showport_parser.py
+++ b/hpe3parclient/showport_parser.py
@@ -29,7 +29,7 @@ class ShowportParser:
     """ Parses the following showport commands on an HP 3par array
         showport
         showport -iscsi
-        showpoer -iscsivlan
+        showport -iscsivlan
     """
 
     def __init__(self):

--- a/test/test_HPE3ParClient_ShowportParser.py
+++ b/test/test_HPE3ParClient_ShowportParser.py
@@ -14,12 +14,12 @@
 
 """Test class of 3PAR Client handling parsing of showport commands."""
 
-from test import HP3ParClient_base as hp3parbase
+from test import HPE3ParClient_base as hp3parbase
 from hpe3parclient import client
-from hpe3parclient.client import  ShowportParser
+#from hpe3parclient.client import ShowportParser
+from hpe3parclient import showport_parser
 
-
-class HP3ParClientShowportTestCase(hp3parbase.HP3ParClientBaseTestCase):
+class HP3ParClientShowportTestCase(hp3parbase.HPE3ParClientBaseTestCase):
 
     def setUp(self):
         super(HP3ParClientShowportTestCase, self).setUp()
@@ -29,7 +29,7 @@ class HP3ParClientShowportTestCase(hp3parbase.HP3ParClientBaseTestCase):
 
     def test_parse_showport_iscsivlans(self):
 
-        parsed_ports = ShowportParser().parseShowport(ports_iscsivlan)
+        parsed_ports = showport_parser.ShowportParser().parseShowport(ports_iscsivlan)
     
         if(parsed_ports != parsed_ports_key):
             err_msg = 'parsed ports does not match key output: {}'
@@ -42,7 +42,7 @@ class HP3ParClientShowportTestCase(hp3parbase.HP3ParClientBaseTestCase):
                  '---------------------------------------------------------------------------------------', 
                  '0,,,,,,,,,']
 
-        parsed_ports = ShowportParser().parseShowport(ports)
+        parsed_ports = showport_parser.ShowportParser().parseShowport(ports)
 
         if (len(parsed_ports) != 0):
             err_msg = 'Parsed ports should be empty but contains data: {}'
@@ -51,13 +51,13 @@ class HP3ParClientShowportTestCase(hp3parbase.HP3ParClientBaseTestCase):
         return
 
     def test_clone_ports(self):
-        parsed_ports = ShowportParser().parseShowport(ports_iscsivlan)
+        parsed_ports = showport_parser.ShowportParser().parseShowport(ports_iscsivlan)
 
         expanded_ports = self.cl._cloneISCSIPorts(real_ports, parsed_ports)
 
         if (expanded_ports != expanded_ports_key):
             err_msg = 'combined ports output does not match test key: {}'
-            return self.fail(err_msg.format(total_ports))
+            return self.fail(err_msg.format(expanded_ports))
 
         return
 

--- a/test/test_HPE3ParClient_ShowportParser.py
+++ b/test/test_HPE3ParClient_ShowportParser.py
@@ -419,86 +419,87 @@ class HP3ParClientShowportTestCase(hp3parbase.HPE3ParClientBaseTestCase):
                ]
             }
 
-
     global parsed_ports_key
-    parsed_ports_key =[  
-               {  
-                  'IPAddr':'172.20.0.150',
-                  'portPos':{  
-                 'node':0,
-                 'slot':2,
-                 'cardPort':1
-                  },
-                  'iSCSIPortInfo':{  
-                 'iSNSAddr':'0.0.0.0',
-                 'vlan':101,
-                 'IPAddr':'172.20.0.150',
-                 'mtu':9000,
-                 'stgt':1024,
-                 'netmask':'255.255.255.0',
-                 'tpgt':1024,
-                 'iSNSPort':3205,
-                 'gateway':'172.20.0.1'
-                  }
-               },
-               {  
-                  'IPAddr':'172.20.1.150',
-                  'portPos':{  
-                 'node':0,
-                 'slot':2,
-                 'cardPort':2
-                  },
-                  'iSCSIPortInfo':{  
-                 'iSNSAddr':'0.0.0.0',
-                 'vlan':102,
-                 'IPAddr':'172.20.1.150',
-                 'mtu':9000,
-                 'stgt':1025,
-                 'netmask':'255.255.255.0',
-                 'tpgt':1025,
-                 'iSNSPort':3205,
-                 'gateway':'172.20.1.1'
-                  }
-               },
-               {  
-                  'IPAddr':'172.20.0.151',
-                  'portPos':{  
-                 'node':1,
-                 'slot':2,
-                 'cardPort':1
-                  },
-                  'iSCSIPortInfo':{  
-                 'iSNSAddr':'0.0.0.0',
-                 'vlan':101,
-                 'IPAddr':'172.20.0.151',
-                 'mtu':9000,
-                 'stgt':1026,
-                 'netmask':'255.255.255.0',
-                 'tpgt':1026,
-                 'iSNSPort':3205,
-                 'gateway':'172.20.0.1'
-                  }
-               },
-               {  
-                  'IPAddr':'172.20.1.151',
-                  'portPos':{  
-                 'node':1,
-                 'slot':2,
-                 'cardPort':2
-                  },
-                  'iSCSIPortInfo':{  
-                 'iSNSAddr':'0.0.0.0',
-                 'vlan':102,
-                 'IPAddr':'172.20.1.151',
-                 'mtu':9000,
-                 'stgt':1027,
-                 'netmask':'255.255.255.0',
-                 'tpgt':1027,
-                 'iSNSPort':3205,
-                 'gateway':'172.20.1.1'
-                  }
-               }
-              ]
+
+    parsed_ports_key = [
+        {
+            'IPAddr': '172.20.0.150',
+            'portPos': {
+                'node': 0,
+                'slot': 2,
+                'cardPort': 1
+            },
+            'iSCSIPortInfo': {
+                'iSNSAddr': '0.0.0.0',
+                'vlan': '101',
+                'IPAddr': '172.20.0.150',
+                'mtu': 9000,
+                'stgt': 1024,
+                'netmask': '255.255.255.0',
+                'tpgt': 1024,
+                'iSNSPort': 3205,
+                'gateway': '172.20.0.1'
+            }
+        },
+        {
+            'IPAddr': '172.20.1.150',
+            'portPos': {
+                'node': 0,
+                'slot': 2,
+                'cardPort': 2
+            },
+            'iSCSIPortInfo': {
+                'iSNSAddr': '0.0.0.0',
+                'vlan': '102',
+                'IPAddr': '172.20.1.150',
+                'mtu': 9000,
+                'stgt': 1025,
+                'netmask': '255.255.255.0',
+                'tpgt': 1025,
+                'iSNSPort': 3205,
+                'gateway': '172.20.1.1'
+            }
+        },
+        {
+            'IPAddr': '172.20.0.151',
+            'portPos': {
+                'node': 1,
+                'slot': 2,
+                'cardPort': 1
+            },
+            'iSCSIPortInfo': {
+                'iSNSAddr': '0.0.0.0',
+                'vlan': '101',
+                'IPAddr': '172.20.0.151',
+                'mtu': 9000,
+                'stgt': 1026,
+                'netmask': '255.255.255.0',
+                'tpgt': 1026,
+                'iSNSPort': 3205,
+                'gateway': '172.20.0.1'
+            }
+        },
+        {
+            'IPAddr': '172.20.1.151',
+            'portPos': {
+                'node': 1,
+                'slot': 2,
+                'cardPort': 2
+            },
+            'iSCSIPortInfo': {
+                'iSNSAddr': '0.0.0.0',
+                'vlan': '102',
+                'IPAddr': '172.20.1.151',
+                'mtu': 9000,
+                'stgt': 1027,
+                'netmask': '255.255.255.0',
+                'tpgt': 1027,
+                'iSNSPort': 3205,
+                'gateway': '172.20.1.1'
+            }
+        }
+    ]
+
 
     global expanded_ports_key
     expanded_ports_key = [  
@@ -518,7 +519,7 @@ class HP3ParClientShowportTestCase(hp3parbase.HPE3ParClientBaseTestCase):
                                  u'slot':2
                               },
                               u'iSCSIPortInfo':{  
-                                 'vlan':101,
+                                 'vlan':'101',
                                  'gateway':'172.20.0.1',
                                  'iSNSPort':3205,
                                  'mtu':9000,
@@ -552,7 +553,7 @@ class HP3ParClientShowportTestCase(hp3parbase.HPE3ParClientBaseTestCase):
                                  u'slot':2
                               },
                               u'iSCSIPortInfo':{  
-                                 'vlan':102,
+                                 'vlan':'102',
                                  'gateway':'172.20.1.1',
                                  'iSNSPort':3205,
                                  'mtu':9000,
@@ -586,7 +587,7 @@ class HP3ParClientShowportTestCase(hp3parbase.HPE3ParClientBaseTestCase):
                                  u'slot':2
                               },
                               u'iSCSIPortInfo':{  
-                                 'vlan':101,
+                                 'vlan':'101',
                                  'gateway':'172.20.0.1',
                                  'iSNSPort':3205,
                                  'mtu':9000,
@@ -620,7 +621,7 @@ class HP3ParClientShowportTestCase(hp3parbase.HPE3ParClientBaseTestCase):
                                  u'slot':2
                               },
                               u'iSCSIPortInfo':{  
-                                 'vlan':102,
+                                 'vlan':'102',
                                  'gateway':'172.20.1.1',
                                  'iSNSPort':3205,
                                  'mtu':9000,
@@ -639,3 +640,4 @@ class HP3ParClientShowportTestCase(hp3parbase.HPE3ParClientBaseTestCase):
                               u'mode':2
                            }
                         ]
+

--- a/test/test_HPE3ParClient_ShowportParser.py
+++ b/test/test_HPE3ParClient_ShowportParser.py
@@ -1,0 +1,641 @@
+# (c) Copyright 2015 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test class of 3PAR Client handling parsing of showport commands."""
+
+from test import HP3ParClient_base as hp3parbase
+from hpe3parclient import client
+from hpe3parclient.client import  ShowportParser
+
+
+class HP3ParClientShowportTestCase(hp3parbase.HP3ParClientBaseTestCase):
+
+    def setUp(self):
+        super(HP3ParClientShowportTestCase, self).setUp()
+
+    def tearDown(self):
+        super(HP3ParClientShowportTestCase, self).tearDown()
+
+    def test_parse_showport_iscsivlans(self):
+
+        parsed_ports = ShowportParser().parseShowport(ports_iscsivlan)
+    
+        if(parsed_ports != parsed_ports_key):
+            err_msg = 'parsed ports does not match key output: {}'
+            return self.fail(err_msg.format(parsed_ports))
+
+        return
+
+    def test_parse_showport_empty(self):
+        ports = ['N:S:P,VLAN,IPAddr,Netmask/PrefixLen,Gateway,MTU,TPGT,STGT,iSNS_Addr,iSNS_Port',
+                 '---------------------------------------------------------------------------------------', 
+                 '0,,,,,,,,,']
+
+        parsed_ports = ShowportParser().parseShowport(ports)
+
+        if (len(parsed_ports) != 0):
+            err_msg = 'Parsed ports should be empty but contains data: {}'
+            return self.fail(err_msg.format(parsed_ports))
+
+        return
+
+    def test_clone_ports(self):
+        parsed_ports = ShowportParser().parseShowport(ports_iscsivlan)
+
+        expanded_ports = self.cl._cloneISCSIPorts(real_ports, parsed_ports)
+
+        if (expanded_ports != expanded_ports_key):
+            err_msg = 'combined ports output does not match test key: {}'
+            return self.fail(err_msg.format(total_ports))
+
+        return
+
+
+
+    global ports_iscsivlan
+    ports_iscsivlan = ['N:S:P,VLAN,IPAddr,Netmask/PrefixLen,Gateway,MTU,TPGT,STGT,iSNS_Addr,iSNS_Port',
+                       '0:2:1,101,172.20.0.150,255.255.255.0,172.20.0.1,9000,1024,1024,0.0.0.0,3205',
+                       '0:2:2,102,172.20.1.150,255.255.255.0,172.20.1.1,9000,1025,1025,0.0.0.0,3205',
+                       '1:2:1,101,172.20.0.151,255.255.255.0,172.20.0.1,9000,1026,1026,0.0.0.0,3205',
+                       '1:2:2,102,172.20.1.151,255.255.255.0,172.20.1.1,9000,1027,1027,0.0.0.0,3205',
+                       '---------------------------------------------------------------------------------------',
+                       '4,,,,,,,,,']
+
+    global real_ports
+    real_ports = {  
+               u'total':14,
+               u'members':[  
+                  {  
+                 u'portWWN':u'20010002AC01C533',
+                 u'protocol':1,
+                 u'partnerPos':{  
+                    u'node':1,
+                    u'slot':0,
+                    u'cardPort':1
+                 },
+                 u'linkState':5,
+                 u'failoverState':1,
+                 u'mode':2,
+                 u'device':[  
+
+                 ],
+                 u'nodeWWN':u'2FF70002AC01C533',
+                 u'type':3,
+                 u'portPos':{  
+                    u'node':0,
+                    u'slot':0,
+                    u'cardPort':1
+                 }
+                  },
+                  {  
+                 u'portWWN':u'20020002AC01C533',
+                 u'protocol':1,
+                 u'partnerPos':{  
+                    u'node':1,
+                    u'slot':0,
+                    u'cardPort':2
+                 },
+                 u'linkState':5,
+                 u'failoverState':1,
+                 u'mode':2,
+                 u'device':[  
+
+                 ],
+                 u'nodeWWN':u'2FF70002AC01C533',
+                 u'type':3,
+                 u'portPos':{  
+                    u'node':0,
+                    u'slot':0,
+                    u'cardPort':2
+                 }
+                  },
+                  {  
+                 u'portWWN':u'50002AC01101C533',
+                 u'protocol':5,
+                 u'linkState':4,
+                 u'label':u'DP-1',
+                 u'mode':3,
+                 u'device':[  
+                    u'cage0',
+                    u'cage1',
+                    u'cage2'
+                 ],
+                 u'nodeWWN':u'50002ACFF701C533',
+                 u'type':2,
+                 u'portPos':{  
+                    u'node':0,
+                    u'slot':1,
+                    u'cardPort':1
+                 }
+                  },
+                  {  
+                 u'portWWN':u'50002AC01201C533',
+                 u'protocol':5,
+                 u'linkState':4,
+                 u'label':u'DP-2',
+                 u'mode':3,
+                 u'device':[  
+                    u'cage3',
+                    u'cage4',
+                    u'cage5'
+                 ],
+                 u'nodeWWN':u'50002ACFF701C533',
+                 u'type':2,
+                 u'portPos':{  
+                    u'node':0,
+                    u'slot':1,
+                    u'cardPort':2
+                 }
+                  },
+                  {  
+                 u'portPos':{  
+                    u'node':0,
+                    u'slot':2,
+                    u'cardPort':1
+                 },
+                 u'protocol':2,
+                 u'iSCSIPortInfo':{  
+                    u'iSNSAddr':u'0.0.0.0',
+                    u'vlan':1,
+                    u'IPAddr':u'0.0.0.0',
+                    u'rate':u'10Gbps',
+                    u'mtu':9000,
+                    u'stgt':21,
+                    u'netmask':u'0.0.0.0',
+                    u'iSCSIName': u'iqn.2000-05.com.3pardata:20210002ac01c533',
+                    u'tpgt':21,
+                    u'iSNSPort':3205,
+                    u'gateway':u'172.20.0.1'
+                 },
+                 u'partnerPos':{  
+                    u'node':1,
+                    u'slot':2,
+                    u'cardPort':1
+                 },
+                 u'IPAddr':u'0.0.0.0',
+                 u'linkState':4,
+                 u'device':[  
+
+                 ],
+                 u'iSCSIName': u'iqn.2000-05.com.3pardata:20210002ac01c533',
+                 u'failoverState':1,
+                 u'mode':2,
+                 u'HWAddr':u'1402EC613AFA',
+                 u'type':8
+                  },
+                  {  
+                 u'portPos':{  
+                    u'node':0,
+                    u'slot':2,
+                    u'cardPort':2
+                 },
+                 u'protocol':2,
+                 u'iSCSIPortInfo':{  
+                    u'iSNSAddr':u'0.0.0.0',
+                    u'vlan':1,
+                    u'IPAddr':u'0.0.0.0',
+                    u'rate':u'10Gbps',
+                    u'mtu':1500,
+                    u'stgt':22,
+                    u'netmask':u'0.0.0.0',
+                    u'iSCSIName': u'iqn.2000-05.com.3pardata:20220002ac01c533',
+                    u'tpgt':22,
+                    u'iSNSPort':3205,
+                    u'gateway':u'0.0.0.0'
+                 },
+                 u'partnerPos':{  
+                    u'node':1,
+                    u'slot':2,
+                    u'cardPort':2
+                 },
+                 u'IPAddr':u'0.0.0.0',
+                 u'linkState':4,
+                 u'device':[  
+
+                 ],
+                 u'iSCSIName': u'iqn.2000-05.com.3pardata:20220002ac01c533',
+                 u'failoverState':1,
+                 u'mode':2,
+                 u'HWAddr':u'1402EC613AF2',
+                 u'type':8
+                  },
+                  {  
+                 u'portPos':{  
+                    u'node':0,
+                    u'slot':3,
+                    u'cardPort':1
+                 },
+                 u'protocol':4,
+                 u'linkState':10,
+                 u'label':u'IP0',
+                 u'device':[  
+
+                 ],
+                 u'mode':4,
+                 u'HWAddr':u'941882447BDD',
+                 u'type':3
+                  },
+                  {  
+                 u'portWWN':u'21010002AC01C533',
+                 u'protocol':1,
+                 u'partnerPos':{  
+                    u'node':0,
+                    u'slot':0,
+                    u'cardPort':1
+                 },
+                 u'linkState':5,
+                 u'failoverState':1,
+                 u'mode':2,
+                 u'device':[  
+
+                 ],
+                 u'nodeWWN':u'2FF70002AC01C533',
+                 u'type':3,
+                 u'portPos':{  
+                    u'node':1,
+                    u'slot':0,
+                    u'cardPort':1
+                 }
+                  },
+                  {  
+                 u'portWWN':u'21020002AC01C533',
+                 u'protocol':1,
+                 u'partnerPos':{  
+                    u'node':0,
+                    u'slot':0,
+                    u'cardPort':2
+                 },
+                 u'linkState':5,
+                 u'failoverState':1,
+                 u'mode':2,
+                 u'device':[  
+
+                 ],
+                 u'nodeWWN':u'2FF70002AC01C533',
+                 u'type':3,
+                 u'portPos':{  
+                    u'node':1,
+                    u'slot':0,
+                    u'cardPort':2
+                 }
+                  },
+                  {  
+                 u'portWWN':u'50002AC11101C533',
+                 u'protocol':5,
+                 u'linkState':4,
+                 u'label':u'DP-1',
+                 u'mode':3,
+                 u'device':[  
+                    u'cage0',
+                    u'cage1',
+                    u'cage2'
+                 ],
+                 u'nodeWWN':u'50002ACFF701C533',
+                 u'type':2,
+                 u'portPos':{  
+                    u'node':1,
+                    u'slot':1,
+                    u'cardPort':1
+                 }
+                  },
+                  {  
+                 u'portWWN':u'50002AC11201C533',
+                 u'protocol':5,
+                 u'linkState':4,
+                 u'label':u'DP-2',
+                 u'mode':3,
+                 u'device':[  
+                    u'cage3',
+                    u'cage4',
+                    u'cage5'
+                 ],
+                 u'nodeWWN':u'50002ACFF701C533',
+                 u'type':2,
+                 u'portPos':{  
+                    u'node':1,
+                    u'slot':1,
+                    u'cardPort':2
+                 }
+                  },
+                  {  
+                 u'portPos':{  
+                    u'node':1,
+                    u'slot':2,
+                    u'cardPort':1
+                 },
+                 u'protocol':2,
+                 u'iSCSIPortInfo':{  
+                    u'iSNSAddr':u'0.0.0.0',
+                    u'vlan':1,
+                    u'IPAddr':u'0.0.0.0',
+                    u'rate':u'10Gbps',
+                    u'mtu':1500,
+                    u'stgt':121,
+                    u'netmask':u'0.0.0.0',
+                    u'iSCSIName': u'iqn.2000-05.com.3pardata:21210002ac01c533',
+                    u'tpgt':121,
+                    u'iSNSPort':3205,
+                    u'gateway':u'0.0.0.0'
+                 },
+                 u'partnerPos':{  
+                    u'node':0,
+                    u'slot':2,
+                    u'cardPort':1
+                 },
+                 u'IPAddr':u'0.0.0.0',
+                 u'linkState':4,
+                 u'device':[  
+
+                 ],
+                 u'iSCSIName': u'iqn.2000-05.com.3pardata:21210002ac01c533',
+                 u'failoverState':1,
+                 u'mode':2,
+                 u'HWAddr':u'1402EC613B0A',
+                 u'type':8
+                  },
+                  {  
+                 u'portPos':{  
+                    u'node':1,
+                    u'slot':2,
+                    u'cardPort':2
+                 },
+                 u'protocol':2,
+                 u'iSCSIPortInfo':{  
+                    u'iSNSAddr':u'0.0.0.0',
+                    u'vlan':1,
+                    u'IPAddr':u'0.0.0.0',
+                    u'rate':u'10Gbps',
+                    u'mtu':1500,
+                    u'stgt':122,
+                    u'netmask':u'0.0.0.0',
+                    u'iSCSIName': u'iqn.2000-05.com.3pardata:21220002ac01c533',
+                    u'tpgt':122,
+                    u'iSNSPort':3205,
+                    u'gateway':u'0.0.0.0'
+                 },
+                 u'partnerPos':{  
+                    u'node':0,
+                    u'slot':2,
+                    u'cardPort':2
+                 },
+                 u'IPAddr':u'0.0.0.0',
+                 u'linkState':4,
+                 u'device':[  
+
+                 ],
+                 u'iSCSIName': u'iqn.2000-05.com.3pardata:21220002ac01c533',
+                 u'failoverState':1,
+                 u'mode':2,
+                 u'HWAddr':u'1402EC613B02',
+                 u'type':8
+                  },
+                  {  
+                 u'portPos':{  
+                    u'node':1,
+                    u'slot':3,
+                    u'cardPort':1
+                 },
+                 u'protocol':4,
+                 u'linkState':10,
+                 u'label':u'IP1',
+                 u'device':[  
+
+                 ],
+                 u'mode':4,
+                 u'HWAddr':u'941882447CED',
+                 u'type':3
+                  }
+               ]
+            }
+
+
+    global parsed_ports_key
+    parsed_ports_key =[  
+               {  
+                  'IPAddr':'172.20.0.150',
+                  'portPos':{  
+                 'node':0,
+                 'slot':2,
+                 'cardPort':1
+                  },
+                  'iSCSIPortInfo':{  
+                 'iSNSAddr':'0.0.0.0',
+                 'vlan':101,
+                 'IPAddr':'172.20.0.150',
+                 'mtu':9000,
+                 'stgt':1024,
+                 'netmask':'255.255.255.0',
+                 'tpgt':1024,
+                 'iSNSPort':3205,
+                 'gateway':'172.20.0.1'
+                  }
+               },
+               {  
+                  'IPAddr':'172.20.1.150',
+                  'portPos':{  
+                 'node':0,
+                 'slot':2,
+                 'cardPort':2
+                  },
+                  'iSCSIPortInfo':{  
+                 'iSNSAddr':'0.0.0.0',
+                 'vlan':102,
+                 'IPAddr':'172.20.1.150',
+                 'mtu':9000,
+                 'stgt':1025,
+                 'netmask':'255.255.255.0',
+                 'tpgt':1025,
+                 'iSNSPort':3205,
+                 'gateway':'172.20.1.1'
+                  }
+               },
+               {  
+                  'IPAddr':'172.20.0.151',
+                  'portPos':{  
+                 'node':1,
+                 'slot':2,
+                 'cardPort':1
+                  },
+                  'iSCSIPortInfo':{  
+                 'iSNSAddr':'0.0.0.0',
+                 'vlan':101,
+                 'IPAddr':'172.20.0.151',
+                 'mtu':9000,
+                 'stgt':1026,
+                 'netmask':'255.255.255.0',
+                 'tpgt':1026,
+                 'iSNSPort':3205,
+                 'gateway':'172.20.0.1'
+                  }
+               },
+               {  
+                  'IPAddr':'172.20.1.151',
+                  'portPos':{  
+                 'node':1,
+                 'slot':2,
+                 'cardPort':2
+                  },
+                  'iSCSIPortInfo':{  
+                 'iSNSAddr':'0.0.0.0',
+                 'vlan':102,
+                 'IPAddr':'172.20.1.151',
+                 'mtu':9000,
+                 'stgt':1027,
+                 'netmask':'255.255.255.0',
+                 'tpgt':1027,
+                 'iSNSPort':3205,
+                 'gateway':'172.20.1.1'
+                  }
+               }
+              ]
+
+    global expanded_ports_key
+    expanded_ports_key = [  
+                           {  
+                              u'portPos':{  
+                                 'node':0,
+                                 'cardPort':1,
+                                 'slot':2
+                              },
+                              u'device':[  
+
+                              ],
+                              u'linkState':4,
+                              u'partnerPos':{  
+                                 u'node':1,
+                                 u'cardPort':1,
+                                 u'slot':2
+                              },
+                              u'iSCSIPortInfo':{  
+                                 'vlan':101,
+                                 'gateway':'172.20.0.1',
+                                 'iSNSPort':3205,
+                                 'mtu':9000,
+                                 'IPAddr':'172.20.0.150',
+                                 'stgt':1024,
+                                 'netmask':'255.255.255.0',
+                                 'tpgt':1024,
+                                 'iSNSAddr':'0.0.0.0'
+                              },
+                              u'type':8,
+                              u'protocol':2,
+                              u'failoverState':1,
+                              u'IPAddr':'172.20.0.150',
+                              u'iSCSIName': u'iqn.2000-05.com.3pardata:20210002ac01c533',
+                              u'HWAddr':u'1402EC613AFA',
+                              u'mode':2
+                           },
+                           {  
+                              u'portPos':{  
+                                 'node':0,
+                                 'cardPort':2,
+                                 'slot':2
+                              },
+                              u'device':[  
+
+                              ],
+                              u'linkState':4,
+                              u'partnerPos':{  
+                                 u'node':1,
+                                 u'cardPort':2,
+                                 u'slot':2
+                              },
+                              u'iSCSIPortInfo':{  
+                                 'vlan':102,
+                                 'gateway':'172.20.1.1',
+                                 'iSNSPort':3205,
+                                 'mtu':9000,
+                                 'IPAddr':'172.20.1.150',
+                                 'stgt':1025,
+                                 'netmask':'255.255.255.0',
+                                 'tpgt':1025,
+                                 'iSNSAddr':'0.0.0.0'
+                              },
+                              u'type':8,
+                              u'protocol':2,
+                              u'failoverState':1,
+                              u'IPAddr':'172.20.1.150',
+                              u'iSCSIName': u'iqn.2000-05.com.3pardata:20220002ac01c533',
+                              u'HWAddr':u'1402EC613AF2',
+                              u'mode':2
+                           },
+                           {  
+                              u'portPos':{  
+                                 'node':1,
+                                 'cardPort':1,
+                                 'slot':2
+                              },
+                              u'device':[  
+
+                              ],
+                              u'linkState':4,
+                              u'partnerPos':{  
+                                 u'node':0,
+                                 u'cardPort':1,
+                                 u'slot':2
+                              },
+                              u'iSCSIPortInfo':{  
+                                 'vlan':101,
+                                 'gateway':'172.20.0.1',
+                                 'iSNSPort':3205,
+                                 'mtu':9000,
+                                 'IPAddr':'172.20.0.151',
+                                 'stgt':1026,
+                                 'netmask':'255.255.255.0',
+                                 'tpgt':1026,
+                                 'iSNSAddr':'0.0.0.0'
+                              },
+                              u'type':8,
+                              u'protocol':2,
+                              u'failoverState':1,
+                              u'IPAddr':'172.20.0.151',
+                              u'iSCSIName': u'iqn.2000-05.com.3pardata:21210002ac01c533',
+                              u'HWAddr':u'1402EC613B0A',
+                              u'mode':2
+                           },
+                           {  
+                              u'portPos':{  
+                                 'node':1,
+                                 'cardPort':2,
+                                 'slot':2
+                              },
+                              u'device':[  
+
+                              ],
+                              u'linkState':4,
+                              u'partnerPos':{  
+                                 u'node':0,
+                                 u'cardPort':2,
+                                 u'slot':2
+                              },
+                              u'iSCSIPortInfo':{  
+                                 'vlan':102,
+                                 'gateway':'172.20.1.1',
+                                 'iSNSPort':3205,
+                                 'mtu':9000,
+                                 'IPAddr':'172.20.1.151',
+                                 'stgt':1027,
+                                 'netmask':'255.255.255.0',
+                                 'tpgt':1027,
+                                 'iSNSAddr':'0.0.0.0'
+                              },
+                              u'type':8,
+                              u'protocol':2,
+                              u'failoverState':1,
+                              u'IPAddr':'172.20.1.151',
+                              u'iSCSIName': u'iqn.2000-05.com.3pardata:21220002ac01c533',
+                              u'HWAddr':u'1402EC613B02',
+                              u'mode':2
+                           }
+                        ]

--- a/test/test_HPE3ParClient_ShowportParser.py
+++ b/test/test_HPE3ParClient_ShowportParser.py
@@ -15,9 +15,10 @@
 """Test class of 3PAR Client handling parsing of showport commands."""
 
 from test import HPE3ParClient_base as hp3parbase
-from hpe3parclient import client
-#from hpe3parclient.client import ShowportParser
+# from hpe3parclient import client
+# from hpe3parclient.client import ShowportParser
 from hpe3parclient import showport_parser
+
 
 class HP3ParClientShowportTestCase(hp3parbase.HPE3ParClientBaseTestCase):
 
@@ -29,395 +30,403 @@ class HP3ParClientShowportTestCase(hp3parbase.HPE3ParClientBaseTestCase):
 
     def test_parse_showport_iscsivlans(self):
 
-        parsed_ports = showport_parser.ShowportParser().parseShowport(ports_iscsivlan)
-    
-        if(parsed_ports != parsed_ports_key):
+        parsed_ports = showport_parser.\
+            ShowportParser().parseShowport(ports_iscsivlan)
+
+        if parsed_ports != parsed_ports_key:
             err_msg = 'parsed ports does not match key output: {}'
             return self.fail(err_msg.format(parsed_ports))
 
         return
 
     def test_parse_showport_empty(self):
-        ports = ['N:S:P,VLAN,IPAddr,Netmask/PrefixLen,Gateway,MTU,TPGT,STGT,iSNS_Addr,iSNS_Port',
-                 '---------------------------------------------------------------------------------------', 
-                 '0,,,,,,,,,']
+        ports = \
+            ['N:S:P,VLAN,IPAddr,Netmask/PrefixLen,Gateway,'
+             'MTU,TPGT,STGT,iSNS_Addr,iSNS_Port',
+             '-----------------------------------------'
+             '----------------------------------------------',
+             '0,,,,,,,,,']
 
         parsed_ports = showport_parser.ShowportParser().parseShowport(ports)
 
-        if (len(parsed_ports) != 0):
+        if len(parsed_ports) != 0:
             err_msg = 'Parsed ports should be empty but contains data: {}'
             return self.fail(err_msg.format(parsed_ports))
 
         return
 
     def test_clone_ports(self):
-        parsed_ports = showport_parser.ShowportParser().parseShowport(ports_iscsivlan)
+        parsed_ports = showport_parser.\
+            ShowportParser().parseShowport(ports_iscsivlan)
 
         expanded_ports = self.cl._cloneISCSIPorts(real_ports, parsed_ports)
 
-        if (expanded_ports != expanded_ports_key):
+        if expanded_ports != expanded_ports_key:
             err_msg = 'combined ports output does not match test key: {}'
             return self.fail(err_msg.format(expanded_ports))
 
         return
 
-
-
     global ports_iscsivlan
-    ports_iscsivlan = ['N:S:P,VLAN,IPAddr,Netmask/PrefixLen,Gateway,MTU,TPGT,STGT,iSNS_Addr,iSNS_Port',
-                       '0:2:1,101,172.20.0.150,255.255.255.0,172.20.0.1,9000,1024,1024,0.0.0.0,3205',
-                       '0:2:2,102,172.20.1.150,255.255.255.0,172.20.1.1,9000,1025,1025,0.0.0.0,3205',
-                       '1:2:1,101,172.20.0.151,255.255.255.0,172.20.0.1,9000,1026,1026,0.0.0.0,3205',
-                       '1:2:2,102,172.20.1.151,255.255.255.0,172.20.1.1,9000,1027,1027,0.0.0.0,3205',
-                       '---------------------------------------------------------------------------------------',
-                       '4,,,,,,,,,']
+    ports_iscsivlan = \
+        ['N:S:P,VLAN,IPAddr,Netmask/PrefixLen,Gateway,MTU,'
+         'TPGT,STGT,iSNS_Addr,iSNS_Port',
+         '0:2:1,101,172.20.0.150,255.255.255.0,'
+         '172.20.0.1,9000,1024,1024,0.0.0.0,3205',
+         '0:2:2,102,172.20.1.150,255.255.255.0,'
+         '172.20.1.1,9000,1025,1025,0.0.0.0,3205',
+         '1:2:1,101,172.20.0.151,255.255.255.0,'
+         '172.20.0.1,9000,1026,1026,0.0.0.0,3205',
+         '1:2:2,102,172.20.1.151,255.255.255.0,'
+         '172.20.1.1,9000,1027,1027,0.0.0.0,3205',
+         '---------------------------------------'
+         '------------------------------------------------',
+         '4,,,,,,,,,']
 
     global real_ports
-    real_ports = {  
-               u'total':14,
-               u'members':[  
-                  {  
-                 u'portWWN':u'20010002AC01C533',
-                 u'protocol':1,
-                 u'partnerPos':{  
-                    u'node':1,
-                    u'slot':0,
-                    u'cardPort':1
-                 },
-                 u'linkState':5,
-                 u'failoverState':1,
-                 u'mode':2,
-                 u'device':[  
-
-                 ],
-                 u'nodeWWN':u'2FF70002AC01C533',
-                 u'type':3,
-                 u'portPos':{  
-                    u'node':0,
-                    u'slot':0,
-                    u'cardPort':1
-                 }
-                  },
-                  {  
-                 u'portWWN':u'20020002AC01C533',
-                 u'protocol':1,
-                 u'partnerPos':{  
-                    u'node':1,
-                    u'slot':0,
-                    u'cardPort':2
-                 },
-                 u'linkState':5,
-                 u'failoverState':1,
-                 u'mode':2,
-                 u'device':[  
-
-                 ],
-                 u'nodeWWN':u'2FF70002AC01C533',
-                 u'type':3,
-                 u'portPos':{  
-                    u'node':0,
-                    u'slot':0,
-                    u'cardPort':2
-                 }
-                  },
-                  {  
-                 u'portWWN':u'50002AC01101C533',
-                 u'protocol':5,
-                 u'linkState':4,
-                 u'label':u'DP-1',
-                 u'mode':3,
-                 u'device':[  
+    real_ports = {
+        u'total': 14,
+        u'members': [
+            {
+                u'portWWN': u'20010002AC01C533',
+                u'protocol': 1,
+                u'partnerPos': {
+                    u'node': 1,
+                    u'slot': 0,
+                    u'cardPort': 1
+                },
+                u'linkState': 5,
+                u'failoverState': 1,
+                u'mode': 2,
+                u'device': [
+                ],
+                u'nodeWWN': u'2FF70002AC01C533',
+                u'type': 3,
+                u'portPos': {
+                    u'node': 0,
+                    u'slot': 0,
+                    u'cardPort': 1
+                }
+            },
+            {
+                u'portWWN': u'20020002AC01C533',
+                u'protocol': 1,
+                u'partnerPos': {
+                    u'node': 1,
+                    u'slot': 0,
+                    u'cardPort': 2
+                },
+                u'linkState': 5,
+                u'failoverState': 1,
+                u'mode': 2,
+                u'device': [
+                ],
+                u'nodeWWN': u'2FF70002AC01C533',
+                u'type': 3,
+                u'portPos': {
+                    u'node': 0,
+                    u'slot': 0,
+                    u'cardPort': 2
+                }
+            },
+            {
+                u'portWWN': u'50002AC01101C533',
+                u'protocol': 5,
+                u'linkState': 4,
+                u'label': u'DP-1',
+                u'mode': 3,
+                u'device': [
                     u'cage0',
                     u'cage1',
                     u'cage2'
-                 ],
-                 u'nodeWWN':u'50002ACFF701C533',
-                 u'type':2,
-                 u'portPos':{  
-                    u'node':0,
-                    u'slot':1,
-                    u'cardPort':1
-                 }
-                  },
-                  {  
-                 u'portWWN':u'50002AC01201C533',
-                 u'protocol':5,
-                 u'linkState':4,
-                 u'label':u'DP-2',
-                 u'mode':3,
-                 u'device':[  
+                ],
+                u'nodeWWN': u'50002ACFF701C533',
+                u'type': 2,
+                u'portPos': {
+                    u'node': 0,
+                    u'slot': 1,
+                    u'cardPort': 1
+                }
+            },
+            {
+                u'portWWN': u'50002AC01201C533',
+                u'protocol': 5,
+                u'linkState': 4,
+                u'label': u'DP-2',
+                u'mode': 3,
+                u'device': [
                     u'cage3',
                     u'cage4',
                     u'cage5'
-                 ],
-                 u'nodeWWN':u'50002ACFF701C533',
-                 u'type':2,
-                 u'portPos':{  
-                    u'node':0,
-                    u'slot':1,
-                    u'cardPort':2
-                 }
-                  },
-                  {  
-                 u'portPos':{  
-                    u'node':0,
-                    u'slot':2,
-                    u'cardPort':1
-                 },
-                 u'protocol':2,
-                 u'iSCSIPortInfo':{  
-                    u'iSNSAddr':u'0.0.0.0',
-                    u'vlan':1,
-                    u'IPAddr':u'0.0.0.0',
-                    u'rate':u'10Gbps',
-                    u'mtu':9000,
-                    u'stgt':21,
-                    u'netmask':u'0.0.0.0',
+                ],
+                u'nodeWWN': u'50002ACFF701C533',
+                u'type': 2,
+                u'portPos': {
+                    u'node': 0,
+                    u'slot': 1,
+                    u'cardPort': 2
+                }
+            },
+            {
+                u'portPos': {
+                    u'node': 0,
+                    u'slot': 2,
+                    u'cardPort': 1
+                },
+                u'protocol': 2,
+                u'iSCSIPortInfo': {
+                    u'iSNSAddr': u'0.0.0.0',
+                    u'vlan': 1,
+                    u'IPAddr': u'0.0.0.0',
+                    u'rate': u'10Gbps',
+                    u'mtu': 9000,
+                    u'stgt': 21,
+                    u'netmask': u'0.0.0.0',
                     u'iSCSIName': u'iqn.2000-05.com.3pardata:20210002ac01c533',
-                    u'tpgt':21,
-                    u'iSNSPort':3205,
-                    u'gateway':u'172.20.0.1'
-                 },
-                 u'partnerPos':{  
-                    u'node':1,
-                    u'slot':2,
-                    u'cardPort':1
-                 },
-                 u'IPAddr':u'0.0.0.0',
-                 u'linkState':4,
-                 u'device':[  
+                    u'tpgt': 21,
+                    u'iSNSPort': 3205,
+                    u'gateway': u'172.20.0.1'
+                },
+                u'partnerPos': {
+                    u'node': 1,
+                    u'slot': 2,
+                    u'cardPort': 1
+                },
+                u'IPAddr': u'0.0.0.0',
+                u'linkState': 4,
+                u'device': [
 
-                 ],
-                 u'iSCSIName': u'iqn.2000-05.com.3pardata:20210002ac01c533',
-                 u'failoverState':1,
-                 u'mode':2,
-                 u'HWAddr':u'1402EC613AFA',
-                 u'type':8
-                  },
-                  {  
-                 u'portPos':{  
-                    u'node':0,
-                    u'slot':2,
-                    u'cardPort':2
-                 },
-                 u'protocol':2,
-                 u'iSCSIPortInfo':{  
-                    u'iSNSAddr':u'0.0.0.0',
-                    u'vlan':1,
-                    u'IPAddr':u'0.0.0.0',
-                    u'rate':u'10Gbps',
-                    u'mtu':1500,
-                    u'stgt':22,
-                    u'netmask':u'0.0.0.0',
+                ],
+                u'iSCSIName': u'iqn.2000-05.com.3pardata:20210002ac01c533',
+                u'failoverState': 1,
+                u'mode': 2,
+                u'HWAddr': u'1402EC613AFA',
+                u'type': 8
+            },
+            {
+                u'portPos': {
+                    u'node': 0,
+                    u'slot': 2,
+                    u'cardPort': 2
+                },
+                u'protocol': 2,
+                u'iSCSIPortInfo': {
+                    u'iSNSAddr': u'0.0.0.0',
+                    u'vlan': 1,
+                    u'IPAddr': u'0.0.0.0',
+                    u'rate': u'10Gbps',
+                    u'mtu': 1500,
+                    u'stgt': 22,
+                    u'netmask': u'0.0.0.0',
                     u'iSCSIName': u'iqn.2000-05.com.3pardata:20220002ac01c533',
-                    u'tpgt':22,
-                    u'iSNSPort':3205,
-                    u'gateway':u'0.0.0.0'
-                 },
-                 u'partnerPos':{  
-                    u'node':1,
-                    u'slot':2,
-                    u'cardPort':2
-                 },
-                 u'IPAddr':u'0.0.0.0',
-                 u'linkState':4,
-                 u'device':[  
+                    u'tpgt': 22,
+                    u'iSNSPort': 3205,
+                    u'gateway': u'0.0.0.0'
+                },
+                u'partnerPos': {
+                    u'node': 1,
+                    u'slot': 2,
+                    u'cardPort': 2
+                },
+                u'IPAddr': u'0.0.0.0',
+                u'linkState': 4,
+                u'device': [
 
-                 ],
-                 u'iSCSIName': u'iqn.2000-05.com.3pardata:20220002ac01c533',
-                 u'failoverState':1,
-                 u'mode':2,
-                 u'HWAddr':u'1402EC613AF2',
-                 u'type':8
-                  },
-                  {  
-                 u'portPos':{  
-                    u'node':0,
-                    u'slot':3,
-                    u'cardPort':1
-                 },
-                 u'protocol':4,
-                 u'linkState':10,
-                 u'label':u'IP0',
-                 u'device':[  
+                ],
+                u'iSCSIName': u'iqn.2000-05.com.3pardata:20220002ac01c533',
+                u'failoverState': 1,
+                u'mode': 2,
+                u'HWAddr': u'1402EC613AF2',
+                u'type': 8
+            },
+            {
+                u'portPos': {
+                    u'node': 0,
+                    u'slot': 3,
+                    u'cardPort': 1
+                },
+                u'protocol': 4,
+                u'linkState': 10,
+                u'label': u'IP0',
+                u'device': [
 
-                 ],
-                 u'mode':4,
-                 u'HWAddr':u'941882447BDD',
-                 u'type':3
-                  },
-                  {  
-                 u'portWWN':u'21010002AC01C533',
-                 u'protocol':1,
-                 u'partnerPos':{  
-                    u'node':0,
-                    u'slot':0,
-                    u'cardPort':1
-                 },
-                 u'linkState':5,
-                 u'failoverState':1,
-                 u'mode':2,
-                 u'device':[  
+                ],
+                u'mode': 4,
+                u'HWAddr': u'941882447BDD',
+                u'type': 3
+            },
+            {
+                u'portWWN': u'21010002AC01C533',
+                u'protocol': 1,
+                u'partnerPos': {
+                    u'node': 0,
+                    u'slot': 0,
+                    u'cardPort': 1
+                },
+                u'linkState': 5,
+                u'failoverState': 1,
+                u'mode': 2,
+                u'device': [
 
-                 ],
-                 u'nodeWWN':u'2FF70002AC01C533',
-                 u'type':3,
-                 u'portPos':{  
-                    u'node':1,
-                    u'slot':0,
-                    u'cardPort':1
-                 }
-                  },
-                  {  
-                 u'portWWN':u'21020002AC01C533',
-                 u'protocol':1,
-                 u'partnerPos':{  
-                    u'node':0,
-                    u'slot':0,
-                    u'cardPort':2
-                 },
-                 u'linkState':5,
-                 u'failoverState':1,
-                 u'mode':2,
-                 u'device':[  
+                ],
+                u'nodeWWN': u'2FF70002AC01C533',
+                u'type': 3,
+                u'portPos': {
+                    u'node': 1,
+                    u'slot': 0,
+                    u'cardPort': 1
+                }
+            },
+            {
+                u'portWWN': u'21020002AC01C533',
+                u'protocol': 1,
+                u'partnerPos': {
+                    u'node': 0,
+                    u'slot': 0,
+                    u'cardPort': 2
+                },
+                u'linkState': 5,
+                u'failoverState': 1,
+                u'mode': 2,
+                u'device': [
 
-                 ],
-                 u'nodeWWN':u'2FF70002AC01C533',
-                 u'type':3,
-                 u'portPos':{  
-                    u'node':1,
-                    u'slot':0,
-                    u'cardPort':2
-                 }
-                  },
-                  {  
-                 u'portWWN':u'50002AC11101C533',
-                 u'protocol':5,
-                 u'linkState':4,
-                 u'label':u'DP-1',
-                 u'mode':3,
-                 u'device':[  
+                ],
+                u'nodeWWN': u'2FF70002AC01C533',
+                u'type': 3,
+                u'portPos': {
+                    u'node': 1,
+                    u'slot': 0,
+                    u'cardPort': 2
+                }
+            },
+            {
+                u'portWWN': u'50002AC11101C533',
+                u'protocol': 5,
+                u'linkState': 4,
+                u'label': u'DP-1',
+                u'mode': 3,
+                u'device': [
                     u'cage0',
                     u'cage1',
                     u'cage2'
-                 ],
-                 u'nodeWWN':u'50002ACFF701C533',
-                 u'type':2,
-                 u'portPos':{  
-                    u'node':1,
-                    u'slot':1,
-                    u'cardPort':1
-                 }
-                  },
-                  {  
-                 u'portWWN':u'50002AC11201C533',
-                 u'protocol':5,
-                 u'linkState':4,
-                 u'label':u'DP-2',
-                 u'mode':3,
-                 u'device':[  
+                ],
+                u'nodeWWN': u'50002ACFF701C533',
+                u'type': 2,
+                u'portPos': {
+                    u'node': 1,
+                    u'slot': 1,
+                    u'cardPort': 1
+                }
+            },
+            {
+                u'portWWN': u'50002AC11201C533',
+                u'protocol': 5,
+                u'linkState': 4,
+                u'label': u'DP-2',
+                u'mode': 3,
+                u'device': [
                     u'cage3',
                     u'cage4',
                     u'cage5'
-                 ],
-                 u'nodeWWN':u'50002ACFF701C533',
-                 u'type':2,
-                 u'portPos':{  
-                    u'node':1,
-                    u'slot':1,
-                    u'cardPort':2
-                 }
-                  },
-                  {  
-                 u'portPos':{  
-                    u'node':1,
-                    u'slot':2,
-                    u'cardPort':1
-                 },
-                 u'protocol':2,
-                 u'iSCSIPortInfo':{  
-                    u'iSNSAddr':u'0.0.0.0',
-                    u'vlan':1,
-                    u'IPAddr':u'0.0.0.0',
-                    u'rate':u'10Gbps',
-                    u'mtu':1500,
-                    u'stgt':121,
-                    u'netmask':u'0.0.0.0',
+                ],
+                u'nodeWWN': u'50002ACFF701C533',
+                u'type': 2,
+                u'portPos': {
+                    u'node': 1,
+                    u'slot': 1,
+                    u'cardPort': 2
+                }
+            },
+            {
+                u'portPos': {
+                    u'node': 1,
+                    u'slot': 2,
+                    u'cardPort': 1
+                },
+                u'protocol': 2,
+                u'iSCSIPortInfo': {
+                    u'iSNSAddr': u'0.0.0.0',
+                    u'vlan': 1,
+                    u'IPAddr': u'0.0.0.0',
+                    u'rate': u'10Gbps',
+                    u'mtu': 1500,
+                    u'stgt': 121,
+                    u'netmask': u'0.0.0.0',
                     u'iSCSIName': u'iqn.2000-05.com.3pardata:21210002ac01c533',
-                    u'tpgt':121,
-                    u'iSNSPort':3205,
-                    u'gateway':u'0.0.0.0'
-                 },
-                 u'partnerPos':{  
-                    u'node':0,
-                    u'slot':2,
-                    u'cardPort':1
-                 },
-                 u'IPAddr':u'0.0.0.0',
-                 u'linkState':4,
-                 u'device':[  
+                    u'tpgt': 121,
+                    u'iSNSPort': 3205,
+                    u'gateway': u'0.0.0.0'
+                },
+                u'partnerPos': {
+                    u'node': 0,
+                    u'slot': 2,
+                    u'cardPort': 1
+                },
+                u'IPAddr': u'0.0.0.0',
+                u'linkState': 4,
+                u'device': [
 
-                 ],
-                 u'iSCSIName': u'iqn.2000-05.com.3pardata:21210002ac01c533',
-                 u'failoverState':1,
-                 u'mode':2,
-                 u'HWAddr':u'1402EC613B0A',
-                 u'type':8
-                  },
-                  {  
-                 u'portPos':{  
-                    u'node':1,
-                    u'slot':2,
-                    u'cardPort':2
-                 },
-                 u'protocol':2,
-                 u'iSCSIPortInfo':{  
-                    u'iSNSAddr':u'0.0.0.0',
-                    u'vlan':1,
-                    u'IPAddr':u'0.0.0.0',
-                    u'rate':u'10Gbps',
-                    u'mtu':1500,
-                    u'stgt':122,
-                    u'netmask':u'0.0.0.0',
+                ],
+                u'iSCSIName': u'iqn.2000-05.com.3pardata:21210002ac01c533',
+                u'failoverState': 1,
+                u'mode': 2,
+                u'HWAddr': u'1402EC613B0A',
+                u'type': 8
+            },
+            {
+                u'portPos': {
+                    u'node': 1,
+                    u'slot': 2,
+                    u'cardPort': 2
+                },
+                u'protocol': 2,
+                u'iSCSIPortInfo': {
+                    u'iSNSAddr': u'0.0.0.0',
+                    u'vlan': 1,
+                    u'IPAddr': u'0.0.0.0',
+                    u'rate': u'10Gbps',
+                    u'mtu': 1500,
+                    u'stgt': 122,
+                    u'netmask': u'0.0.0.0',
                     u'iSCSIName': u'iqn.2000-05.com.3pardata:21220002ac01c533',
-                    u'tpgt':122,
-                    u'iSNSPort':3205,
-                    u'gateway':u'0.0.0.0'
-                 },
-                 u'partnerPos':{  
-                    u'node':0,
-                    u'slot':2,
-                    u'cardPort':2
-                 },
-                 u'IPAddr':u'0.0.0.0',
-                 u'linkState':4,
-                 u'device':[  
+                    u'tpgt': 122,
+                    u'iSNSPort': 3205,
+                    u'gateway': u'0.0.0.0'
+                },
+                u'partnerPos': {
+                    u'node': 0,
+                    u'slot': 2,
+                    u'cardPort': 2
+                },
+                u'IPAddr': u'0.0.0.0',
+                u'linkState': 4,
+                u'device': [
 
-                 ],
-                 u'iSCSIName': u'iqn.2000-05.com.3pardata:21220002ac01c533',
-                 u'failoverState':1,
-                 u'mode':2,
-                 u'HWAddr':u'1402EC613B02',
-                 u'type':8
-                  },
-                  {  
-                 u'portPos':{  
-                    u'node':1,
-                    u'slot':3,
-                    u'cardPort':1
-                 },
-                 u'protocol':4,
-                 u'linkState':10,
-                 u'label':u'IP1',
-                 u'device':[  
+                ],
+                u'iSCSIName': u'iqn.2000-05.com.3pardata:21220002ac01c533',
+                u'failoverState': 1,
+                u'mode': 2,
+                u'HWAddr': u'1402EC613B02',
+                u'type': 8
+            },
+            {
+                u'portPos': {
+                    u'node': 1,
+                    u'slot': 3,
+                    u'cardPort': 1
+                },
+                u'protocol': 4,
+                u'linkState': 10,
+                u'label': u'IP1',
+                u'device': [
 
-                 ],
-                 u'mode':4,
-                 u'HWAddr':u'941882447CED',
-                 u'type':3
-                  }
-               ]
+                ],
+                u'mode': 4,
+                u'HWAddr': u'941882447CED',
+                u'type': 3
             }
+        ]
+    }
 
     global parsed_ports_key
 
@@ -500,144 +509,142 @@ class HP3ParClientShowportTestCase(hp3parbase.HPE3ParClientBaseTestCase):
         }
     ]
 
-
     global expanded_ports_key
-    expanded_ports_key = [  
-                           {  
-                              u'portPos':{  
-                                 'node':0,
-                                 'cardPort':1,
-                                 'slot':2
-                              },
-                              u'device':[  
+    expanded_ports_key = [
+        {
+            u'portPos': {
+                'node': 0,
+                'cardPort': 1,
+                'slot': 2
+            },
+            u'device': [
 
-                              ],
-                              u'linkState':4,
-                              u'partnerPos':{  
-                                 u'node':1,
-                                 u'cardPort':1,
-                                 u'slot':2
-                              },
-                              u'iSCSIPortInfo':{  
-                                 'vlan':'101',
-                                 'gateway':'172.20.0.1',
-                                 'iSNSPort':3205,
-                                 'mtu':9000,
-                                 'IPAddr':'172.20.0.150',
-                                 'stgt':1024,
-                                 'netmask':'255.255.255.0',
-                                 'tpgt':1024,
-                                 'iSNSAddr':'0.0.0.0'
-                              },
-                              u'type':8,
-                              u'protocol':2,
-                              u'failoverState':1,
-                              u'IPAddr':'172.20.0.150',
-                              u'iSCSIName': u'iqn.2000-05.com.3pardata:20210002ac01c533',
-                              u'HWAddr':u'1402EC613AFA',
-                              u'mode':2
-                           },
-                           {  
-                              u'portPos':{  
-                                 'node':0,
-                                 'cardPort':2,
-                                 'slot':2
-                              },
-                              u'device':[  
+            ],
+            u'linkState': 4,
+            u'partnerPos': {
+                u'node': 1,
+                u'cardPort': 1,
+                u'slot': 2
+            },
+            u'iSCSIPortInfo': {
+                'vlan': '101',
+                'gateway': '172.20.0.1',
+                'iSNSPort': 3205,
+                'mtu': 9000,
+                'IPAddr': '172.20.0.150',
+                'stgt': 1024,
+                'netmask': '255.255.255.0',
+                'tpgt': 1024,
+                'iSNSAddr': '0.0.0.0'
+            },
+            u'type': 8,
+            u'protocol': 2,
+            u'failoverState': 1,
+            u'IPAddr': '172.20.0.150',
+            u'iSCSIName': u'iqn.2000-05.com.3pardata:20210002ac01c533',
+            u'HWAddr': u'1402EC613AFA',
+            u'mode': 2
+        },
+        {
+            u'portPos': {
+                'node': 0,
+                'cardPort': 2,
+                'slot': 2
+            },
+            u'device': [
 
-                              ],
-                              u'linkState':4,
-                              u'partnerPos':{  
-                                 u'node':1,
-                                 u'cardPort':2,
-                                 u'slot':2
-                              },
-                              u'iSCSIPortInfo':{  
-                                 'vlan':'102',
-                                 'gateway':'172.20.1.1',
-                                 'iSNSPort':3205,
-                                 'mtu':9000,
-                                 'IPAddr':'172.20.1.150',
-                                 'stgt':1025,
-                                 'netmask':'255.255.255.0',
-                                 'tpgt':1025,
-                                 'iSNSAddr':'0.0.0.0'
-                              },
-                              u'type':8,
-                              u'protocol':2,
-                              u'failoverState':1,
-                              u'IPAddr':'172.20.1.150',
-                              u'iSCSIName': u'iqn.2000-05.com.3pardata:20220002ac01c533',
-                              u'HWAddr':u'1402EC613AF2',
-                              u'mode':2
-                           },
-                           {  
-                              u'portPos':{  
-                                 'node':1,
-                                 'cardPort':1,
-                                 'slot':2
-                              },
-                              u'device':[  
+            ],
+            u'linkState': 4,
+            u'partnerPos': {
+                u'node': 1,
+                u'cardPort': 2,
+                u'slot': 2
+            },
+            u'iSCSIPortInfo': {
+                'vlan': '102',
+                'gateway': '172.20.1.1',
+                'iSNSPort': 3205,
+                'mtu': 9000,
+                'IPAddr': '172.20.1.150',
+                'stgt': 1025,
+                'netmask': '255.255.255.0',
+                'tpgt': 1025,
+                'iSNSAddr': '0.0.0.0'
+            },
+            u'type': 8,
+            u'protocol': 2,
+            u'failoverState': 1,
+            u'IPAddr': '172.20.1.150',
+            u'iSCSIName': u'iqn.2000-05.com.3pardata:20220002ac01c533',
+            u'HWAddr': u'1402EC613AF2',
+            u'mode': 2
+        },
+        {
+            u'portPos': {
+                'node': 1,
+                'cardPort': 1,
+                'slot': 2
+            },
+            u'device': [
 
-                              ],
-                              u'linkState':4,
-                              u'partnerPos':{  
-                                 u'node':0,
-                                 u'cardPort':1,
-                                 u'slot':2
-                              },
-                              u'iSCSIPortInfo':{  
-                                 'vlan':'101',
-                                 'gateway':'172.20.0.1',
-                                 'iSNSPort':3205,
-                                 'mtu':9000,
-                                 'IPAddr':'172.20.0.151',
-                                 'stgt':1026,
-                                 'netmask':'255.255.255.0',
-                                 'tpgt':1026,
-                                 'iSNSAddr':'0.0.0.0'
-                              },
-                              u'type':8,
-                              u'protocol':2,
-                              u'failoverState':1,
-                              u'IPAddr':'172.20.0.151',
-                              u'iSCSIName': u'iqn.2000-05.com.3pardata:21210002ac01c533',
-                              u'HWAddr':u'1402EC613B0A',
-                              u'mode':2
-                           },
-                           {  
-                              u'portPos':{  
-                                 'node':1,
-                                 'cardPort':2,
-                                 'slot':2
-                              },
-                              u'device':[  
+            ],
+            u'linkState': 4,
+            u'partnerPos': {
+                u'node': 0,
+                u'cardPort': 1,
+                u'slot': 2
+            },
+            u'iSCSIPortInfo': {
+                'vlan': '101',
+                'gateway': '172.20.0.1',
+                'iSNSPort': 3205,
+                'mtu': 9000,
+                'IPAddr': '172.20.0.151',
+                'stgt': 1026,
+                'netmask': '255.255.255.0',
+                'tpgt': 1026,
+                'iSNSAddr': '0.0.0.0'
+            },
+            u'type': 8,
+            u'protocol': 2,
+            u'failoverState': 1,
+            u'IPAddr': '172.20.0.151',
+            u'iSCSIName': u'iqn.2000-05.com.3pardata:21210002ac01c533',
+            u'HWAddr': u'1402EC613B0A',
+            u'mode': 2
+        },
+        {
+            u'portPos': {
+                'node': 1,
+                'cardPort': 2,
+                'slot': 2
+            },
+            u'device': [
 
-                              ],
-                              u'linkState':4,
-                              u'partnerPos':{  
-                                 u'node':0,
-                                 u'cardPort':2,
-                                 u'slot':2
-                              },
-                              u'iSCSIPortInfo':{  
-                                 'vlan':'102',
-                                 'gateway':'172.20.1.1',
-                                 'iSNSPort':3205,
-                                 'mtu':9000,
-                                 'IPAddr':'172.20.1.151',
-                                 'stgt':1027,
-                                 'netmask':'255.255.255.0',
-                                 'tpgt':1027,
-                                 'iSNSAddr':'0.0.0.0'
-                              },
-                              u'type':8,
-                              u'protocol':2,
-                              u'failoverState':1,
-                              u'IPAddr':'172.20.1.151',
-                              u'iSCSIName': u'iqn.2000-05.com.3pardata:21220002ac01c533',
-                              u'HWAddr':u'1402EC613B02',
-                              u'mode':2
-                           }
-                        ]
-
+            ],
+            u'linkState': 4,
+            u'partnerPos': {
+                u'node': 0,
+                u'cardPort': 2,
+                u'slot': 2
+            },
+            u'iSCSIPortInfo': {
+                'vlan': '102',
+                'gateway': '172.20.1.1',
+                'iSNSPort': 3205,
+                'mtu': 9000,
+                'IPAddr': '172.20.1.151',
+                'stgt': 1027,
+                'netmask': '255.255.255.0',
+                'tpgt': 1027,
+                'iSNSAddr': '0.0.0.0'
+            },
+            u'type': 8,
+            u'protocol': 2,
+            u'failoverState': 1,
+            u'IPAddr': '172.20.1.151',
+            u'iSCSIName': u'iqn.2000-05.com.3pardata:21220002ac01c533',
+            u'HWAddr': u'1402EC613B02',
+            u'mode': 2
+        }
+    ]

--- a/test/test_HPE3ParClient_ports.py
+++ b/test/test_HPE3ParClient_ports.py
@@ -89,6 +89,10 @@ body = {
     }]
 }
 
+user = "u"
+password = "p"
+ip = "10.10.22.241"
+
 
 class HPE3ParClientPortTestCase(hpe3parbase.HPE3ParClientBaseTestCase):
 
@@ -125,7 +129,9 @@ class HPE3ParClientPortTestCase(hpe3parbase.HPE3ParClientBaseTestCase):
 
     def test_get_ports_ssh(self):
         self.printHeader('get_ports_cli')
-        self.cl.setSSHOptions('192.168.67.7', '3paradm', '3pardata')
+        self.cl.setSSHOptions(ip,
+                              user,
+                              password)
         ports = self.cl.getPorts()
         if ports:
             if len(ports['members']) == ports['total']:

--- a/test/test_HPE3ParClient_ports.py
+++ b/test/test_HPE3ParClient_ports.py
@@ -16,6 +16,78 @@
 
 from test import HPE3ParClient_base as hpe3parbase
 
+iscsi_ports = [{
+	'IPAddr': '192.168.1.1',
+	'portPos': {
+		'node': 0,
+		'slot': 2,
+		'cardPort': 1
+	},
+	'iSCSIPortInfo': {
+		'iSNSAddr': '0.0.0.0',
+		'vlan': '100',
+		'IPAddr': '192.168.1.1',
+		'mtu': 1500,
+		'stgt': 21,
+		'netmask': '255.255.192.0',
+		'tpgt': 1024,
+		'iSNSPort': 3205,
+		'gateway': '0.0.0.0'
+	}
+}]
+
+body = {
+      u'total': 14,
+      u'members': [{
+            u'portPos': {
+                u'node': 0,
+                u'slot': 2,
+                u'cardPort': 1
+            },
+            u'protocol': 2,
+            u'iSCSIPortInfo': {
+                u'iSNSAddr': u'0.0.0.0',
+                u'vlan': 1,
+                u'IPAddr': u'0.0.0.0',
+                u'rate': u'10Gbps',
+                u'mtu': 1500,
+                u'stgt': 21,
+                u'netmask': u'0.0.0.0',
+                u'iSCSIName': u'iqn.2000-05.com.3pardata:20210002ac01db31',
+                u'tpgt': 21,
+                u'iSNSPort': 3205,
+                u'gateway': u'0.0.0.0'
+            },
+            u'partnerPos': {
+                u'node': 1,
+                u'slot': 2,
+                u'cardPort': 1
+            },
+            u'IPAddr': u'0.0.0.0',
+            u'linkState': 4,
+            u'device': [
+
+            ],
+            u'iSCSIName': u'iqn.2000-05.com.3pardata:20210002ac01db31',
+            u'failoverState': 1,
+            u'mode': 2,
+            u'HWAddr': u'70106FCE921A',
+            u'type': 8,
+            u'iSCSIVlans': [
+                {
+                    u'iSNSAddr': u'0.0.0.0',
+                    u'IPAddr': u'192.168.1.1',
+                    u'mtu': 1500,
+                    u'stgt': 21,
+                    u'netmask': u'255.255.192.0',
+                    u'tpgt': 1024,
+                    u'iSNSPort': 3205,
+                    u'gateway': u'0.0.0.0',
+                    u'vlanTag': 100
+                }
+            ]
+        }]
+        }      
 
 class HPE3ParClientPortTestCase(hpe3parbase.HPE3ParClientBaseTestCase):
 
@@ -36,7 +108,32 @@ class HPE3ParClientPortTestCase(hpe3parbase.HPE3ParClientBaseTestCase):
                 self.fail('Number of ports in invalid.')
         else:
             self.fail('Cannot retrieve ports.')
+    
+    def test_cloned_iscsi_ports(self):
+        self.printHeader('get_vlan_tagged_iscsi_port_info')
+        iscsi_port = self.cl._cloneISCSIPorts(body, iscsi_ports)
+        print(iscsi_port)
+        if iscsi_port:
+            if iscsi_port[0]['iSCSIPortInfo']['IPAddr'] == iscsi_ports[0]['IPAddr']:
+                self.printFooter('get_vlan_tagged_iscsi_port_info')
+                return
+            else:
+                self.fail('iSCSIVlan IPAddr is not found')
+        else:
+            self.fail('Cannot retrieve ports')
 
+    def test_get_ports_ssh(self):
+        self.printHeader('get_ports_cli')
+        self.cl.setSSHOptions('192.168.67.7','3paradm','3pardata')
+        ports = self.cl.getPorts()
+        if ports:
+            if len(ports['members']) == ports['total']:
+                self.printFooter('get_ports_cli')
+                return
+            else:
+                self.fail('Number of ports is invalid.')
+        else:
+            self.fail('Cannot retrieve ports.')
     def test_get_ports_fc(self):
         self.printHeader('get_ports_fc')
         fc_ports = self.cl.getFCPorts(4)

--- a/test/test_HPE3ParClient_ports.py
+++ b/test/test_HPE3ParClient_ports.py
@@ -17,77 +17,78 @@
 from test import HPE3ParClient_base as hpe3parbase
 
 iscsi_ports = [{
-	'IPAddr': '192.168.1.1',
-	'portPos': {
-		'node': 0,
-		'slot': 2,
-		'cardPort': 1
-	},
-	'iSCSIPortInfo': {
-		'iSNSAddr': '0.0.0.0',
-		'vlan': '100',
-		'IPAddr': '192.168.1.1',
-		'mtu': 1500,
-		'stgt': 21,
-		'netmask': '255.255.192.0',
-		'tpgt': 1024,
-		'iSNSPort': 3205,
-		'gateway': '0.0.0.0'
-	}
+    'IPAddr': '192.168.1.1',
+    'portPos': {
+        'node': 0,
+        'slot': 2,
+        'cardPort': 1
+    },
+    'iSCSIPortInfo': {
+        'iSNSAddr': '0.0.0.0',
+        'vlan': '100',
+        'IPAddr': '192.168.1.1',
+        'mtu': 1500,
+        'stgt': 21,
+        'netmask': '255.255.192.0',
+        'tpgt': 1024,
+        'iSNSPort': 3205,
+        'gateway': '0.0.0.0'
+    }
 }]
 
 body = {
-      u'total': 14,
-      u'members': [{
-            u'portPos': {
-                u'node': 0,
-                u'slot': 2,
-                u'cardPort': 1
-            },
-            u'protocol': 2,
-            u'iSCSIPortInfo': {
+    u'total': 14,
+    u'members': [{
+        u'portPos': {
+            u'node': 0,
+            u'slot': 2,
+            u'cardPort': 1
+        },
+        u'protocol': 2,
+        u'iSCSIPortInfo': {
+            u'iSNSAddr': u'0.0.0.0',
+            u'vlan': 1,
+            u'IPAddr': u'0.0.0.0',
+            u'rate': u'10Gbps',
+            u'mtu': 1500,
+            u'stgt': 21,
+            u'netmask': u'0.0.0.0',
+            u'iSCSIName': u'iqn.2000-05.com.3pardata:20210002ac01db31',
+            u'tpgt': 21,
+            u'iSNSPort': 3205,
+            u'gateway': u'0.0.0.0'
+        },
+        u'partnerPos': {
+            u'node': 1,
+            u'slot': 2,
+            u'cardPort': 1
+        },
+        u'IPAddr': u'0.0.0.0',
+        u'linkState': 4,
+        u'device': [
+
+        ],
+        u'iSCSIName': u'iqn.2000-05.com.3pardata:20210002ac01db31',
+        u'failoverState': 1,
+        u'mode': 2,
+        u'HWAddr': u'70106FCE921A',
+        u'type': 8,
+        u'iSCSIVlans': [
+            {
                 u'iSNSAddr': u'0.0.0.0',
-                u'vlan': 1,
-                u'IPAddr': u'0.0.0.0',
-                u'rate': u'10Gbps',
+                u'IPAddr': u'192.168.1.1',
                 u'mtu': 1500,
                 u'stgt': 21,
-                u'netmask': u'0.0.0.0',
-                u'iSCSIName': u'iqn.2000-05.com.3pardata:20210002ac01db31',
-                u'tpgt': 21,
+                u'netmask': u'255.255.192.0',
+                u'tpgt': 1024,
                 u'iSNSPort': 3205,
-                u'gateway': u'0.0.0.0'
-            },
-            u'partnerPos': {
-                u'node': 1,
-                u'slot': 2,
-                u'cardPort': 1
-            },
-            u'IPAddr': u'0.0.0.0',
-            u'linkState': 4,
-            u'device': [
+                u'gateway': u'0.0.0.0',
+                u'vlanTag': 100
+            }
+        ]
+    }]
+}
 
-            ],
-            u'iSCSIName': u'iqn.2000-05.com.3pardata:20210002ac01db31',
-            u'failoverState': 1,
-            u'mode': 2,
-            u'HWAddr': u'70106FCE921A',
-            u'type': 8,
-            u'iSCSIVlans': [
-                {
-                    u'iSNSAddr': u'0.0.0.0',
-                    u'IPAddr': u'192.168.1.1',
-                    u'mtu': 1500,
-                    u'stgt': 21,
-                    u'netmask': u'255.255.192.0',
-                    u'tpgt': 1024,
-                    u'iSNSPort': 3205,
-                    u'gateway': u'0.0.0.0',
-                    u'vlanTag': 100
-                }
-            ]
-        }]
-        }      
 
 class HPE3ParClientPortTestCase(hpe3parbase.HPE3ParClientBaseTestCase):
 
@@ -108,13 +109,13 @@ class HPE3ParClientPortTestCase(hpe3parbase.HPE3ParClientBaseTestCase):
                 self.fail('Number of ports in invalid.')
         else:
             self.fail('Cannot retrieve ports.')
-    
+
     def test_cloned_iscsi_ports(self):
         self.printHeader('get_vlan_tagged_iscsi_port_info')
         iscsi_port = self.cl._cloneISCSIPorts(body, iscsi_ports)
-        print(iscsi_port)
         if iscsi_port:
-            if iscsi_port[0]['iSCSIPortInfo']['IPAddr'] == iscsi_ports[0]['IPAddr']:
+            if iscsi_port[0]['iSCSIPortInfo']['IPAddr'] ==\
+                    iscsi_ports[0]['IPAddr']:
                 self.printFooter('get_vlan_tagged_iscsi_port_info')
                 return
             else:
@@ -124,7 +125,7 @@ class HPE3ParClientPortTestCase(hpe3parbase.HPE3ParClientBaseTestCase):
 
     def test_get_ports_ssh(self):
         self.printHeader('get_ports_cli')
-        self.cl.setSSHOptions('192.168.67.7','3paradm','3pardata')
+        self.cl.setSSHOptions('192.168.67.7', '3paradm', '3pardata')
         ports = self.cl.getPorts()
         if ports:
             if len(ports['members']) == ports['total']:
@@ -134,6 +135,7 @@ class HPE3ParClientPortTestCase(hpe3parbase.HPE3ParClientBaseTestCase):
                 self.fail('Number of ports is invalid.')
         else:
             self.fail('Cannot retrieve ports.')
+
     def test_get_ports_fc(self):
         self.printHeader('get_ports_fc')
         fc_ports = self.cl.getFCPorts(4)


### PR DESCRIPTION
Referenced the PR https://github.com/hpe-storage/python-3parclient/pull/30 and made changes on 
"from hpe3parclient import showport_parser" and "return {'iSCSIPortInfo' : {'vlan' : vlan}}"