### PR TITLE
Add py36 and py37 support in tox

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
      'Programming Language :: Python',
      'Programming Language :: Python :: 2.6',
      'Programming Language :: Python :: 2.7',
-     'Programming Language :: Python :: 3.4',
+     'Programming Language :: Python :: 3.6',
+     'Programming Language :: Python :: 3.7',
      'Topic :: Internet :: WWW/HTTP',
 
      ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 1.6
 skipdist = True
-envlist = py27,py34,pep8,cover,docs
+envlist = py27,py36,py37,pep8,cover,docs
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}


### PR DESCRIPTION
This patch adds the python 3.6 and python 3.7 designations in tox tests.

I ran python 37 tests here:
http://paste.openstack.org/show/5TPPZ7E0yIj1K4iyLCEZ/

We need this patch to merge to get openstack upstream global requirments
patch to land so we can add openstack cinder to allow optionally
automatically installing this client lib for users that want a container
with 3par driver support built.

You can view the global requirements patch here:
https://review.opendev.org/#/c/658098/

The cinder patch for optional install of this lib here:
https://review.opendev.org/#/c/656724/