### PR TITLE
Fix for issue #70

### DIFF
--- a/hpe3parclient/showport_parser.py
+++ b/hpe3parclient/showport_parser.py
@@ -60,6 +60,9 @@ class ShowportParser:
         # and the number of entries returned.  We don't want those
         port_show_output = port_show_output[0:-2]
 
+        if not port_show_output:
+            return new_ports
+
         # The first array in the
         # ports output list is the headers
         headers = port_show_output.pop(0).split(',')


### PR DESCRIPTION
Add a condition to find out the parsed output of `showport -iscsivlans` is empty

```
Eg.
chgvash3pt10 cli% showport -iscsivlans
no ports listed
chgvash3pt10 cli% showport -iscsi
N:S:P State   IPAddr  Netmask/PrefixLen Gateway TPGT  MTU Rate iSNS_Addr iSNS_Port STGT VLAN
0:2:1 offline 0.0.0.0 0.0.0.0           0.0.0.0   21 1500  n/a 0.0.0.0        3205   21 Y
0:2:2 offline 0.0.0.0 0.0.0.0           0.0.0.0   22 1500  n/a 0.0.0.0        3205   22 Y
1:2:1 offline 0.0.0.0 0.0.0.0           0.0.0.0  121 1500  n/a 0.0.0.0        3205  121 Y
1:2:2 offline 0.0.0.0 0.0.0.0           0.0.0.0  122 1500  n/a 0.0.0.0        3205  122 Y
--------------------------------------------------------------------------------------------

```