### PR TITLE
Added support for growVolume call to convert size of volume to integer

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,9 @@
 Changelog
 =========
+Changes in Version 4.2.11
+------------------------
+* Added support in growVolume call to take integer value of size
+
 Changes in Version 4.2.10
 ------------------------
 * Added support for Primera array

--- a/hpe3parclient/__init__.py
+++ b/hpe3parclient/__init__.py
@@ -22,7 +22,7 @@ HPE 3PAR Client.
 
 """
 
-version_tuple = (4, 2, 10)
+version_tuple = (4, 2, 11)
 
 
 def get_version_string():

--- a/hpe3parclient/client.py
+++ b/hpe3parclient/client.py
@@ -796,7 +796,7 @@ class HPE3ParClient(object):
 
         """
         info = {'action': self.GROW_VOLUME,
-                'sizeMiB': amount}
+                'sizeMiB': int(amount)}
 
         response, body = self.http.put('/volumes/%s' % name, body=info)
         return body

--- a/test/test_HPE3ParClient_volume.py
+++ b/test/test_HPE3ParClient_volume.py
@@ -424,7 +424,7 @@ class HPE3ParClientVolumeTestCase(hpe3parbase.HPE3ParClientBaseTestCase):
 
         self.printFooter('grow_volume')
 
-   def test_5_grow_volume_with_float_value(self):
+    def test_5_grow_volume_with_float_value(self):
         self.printHeader('grow_volume_with_float_value')
 
         # add one

--- a/test/test_HPE3ParClient_volume.py
+++ b/test/test_HPE3ParClient_volume.py
@@ -424,6 +424,22 @@ class HPE3ParClientVolumeTestCase(hpe3parbase.HPE3ParClientBaseTestCase):
 
         self.printFooter('grow_volume')
 
+   def test_5_grow_volume_with_float_value(self):
+        self.printHeader('grow_volume_with_float_value')
+
+        # add one
+        optional = {'comment': 'test volume', 'tpvv': True}
+        self.cl.createVolume(VOLUME_NAME1, CPG_NAME1, SIZE, optional)
+
+        # grow it
+        result = self.cl.growVolume(VOLUME_NAME1, 1.0)
+
+        result = self.cl.getVolume(VOLUME_NAME1)
+        size_after = result['sizeMiB']
+        self.assertGreater(size_after, SIZE)
+
+        self.printFooter('grow_volume_with_float_value')
+
     def test_5_grow_volume_bad(self):
         self.printHeader('grow_volume_bad')
 


### PR DESCRIPTION
On python2.x, from cinder when growVolume is invoked it passes the size value as integer. But on python3.x, due to division(/) operation giving float values, growVolume call fails as 3par support integer value to grow the volume.

Example:
On python2.x:
Python 2.7.12 (default, Nov 12 2018, 14:36:49)
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> print(1/1)
1

On python3.x:
Python 3.7.4 (default, Sep  2 2019, 20:44:09)
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> print(1/1)
1.0
>>> print(int(1/1))
1
