### PR TITLE
missing slash in spacereporter uri request

### DIFF
--- a/hpe3parclient/client.py
+++ b/hpe3parclient/client.py
@@ -4304,7 +4304,7 @@ class HPE3ParClient(object):
         if interval not in ['daily', 'hourly']:
             raise exceptions.ClientException("Input interval not valid")
 
-        uri = 'systemreporter/vstime/cpgstatistics/' + interval
+        uri = '/systemreporter/vstime/cpgstatistics/' + interval
 
         output = {}
         try:


### PR DESCRIPTION
missing slash in spacereporter uri request causes an error
RESP BODY:{"code":9,"desc":"unsupported operation for the resource"}
