### PR TITLE
Fix-wrong-dictionary-keys-for-systemreporter-vstime-cpgstatistics

### DIFF
--- a/hpe3parclient/client.py
+++ b/hpe3parclient/client.py
@@ -4304,7 +4304,7 @@ class HPE3ParClient(object):
         if interval not in ['daily', 'hourly']:
             raise exceptions.ClientException("Input interval not valid")
 
-        uri = 'systemreporter/vstime/cpgstatistics/' + interval
+        uri = '/systemreporter/vstime/cpgstatistics/' + interval
 
         output = {}
         try:
@@ -4312,10 +4312,10 @@ class HPE3ParClient(object):
             cpg_details = body['members'][-1]
 
             output = {
-                'throughput': float(cpg_details['throughputKByteSec']),
-                'bandwidth': float(cpg_details['bwLimit']),
-                'latency': float(cpg_details['latency']),
-                'io_size': float(cpg_details['IOSizeKB']),
+                'throughput': float(cpg_details['IO']['total']),
+                'bandwidth': float(cpg_details['KBytes']['total']),
+                'latency': float(cpg_details['serviceTimeMS']['total']),
+                'io_size': float(cpg_details['IOSizeKB']['total']),
                 'queue_length': float(cpg_details['queueLength']),
                 'avg_busy_perc': float(cpg_details['busyPct'])
             }


### PR DESCRIPTION
according to HPE Primera Web Services API  Developer Guide
Table 367: Versus Time CPG statistical data JSON object members
key names have been changed


